### PR TITLE
typos

### DIFF
--- a/not-to-release/sources/answers/20090205181308AAZghOH_ans.xml.conllu
+++ b/not-to-release/sources/answers/20090205181308AAZghOH_ans.xml.conllu
@@ -72,7 +72,7 @@
 
 # sent_id = answers-20090205181308AAZghOH_ans-0003
 # text = amd i like 2 guys
-1	amd	amd	CCONJ	CC	_	3	cc	3:cc	_
+1	amd	and	CCONJ	CC	Typo=Yes	3	cc	3:cc	_
 2	i	i	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	3	nsubj	3:nsubj	_
 3	like	like	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 4	2	2	NUM	CD	NumType=Card	5	nummod	5:nummod	_

--- a/not-to-release/sources/answers/20111106144630AAadR8l_ans.xml.conllu
+++ b/not-to-release/sources/answers/20111106144630AAadR8l_ans.xml.conllu
@@ -271,7 +271,7 @@
 21	McNamara	McNamara	PROPN	NNP	Number=Sing	23	nsubj	23:nsubj	_
 22	was	be	AUX	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	23	cop	23:cop	_
 23	nothing	nothing	PRON	NN	Number=Sing	18	parataxis	18:parataxis	_
-24	if	if	ADP	IN	_	25	mark	25:mark	_
+24	if	if	SCONJ	IN	_	25	mark	25:mark	_
 25	not	not	ADV	RB	_	29	advmod	29:advmod	_
 26	a	a	DET	DT	Definite=Ind|PronType=Art	29	det	29:det	_
 27	bean	bean	NOUN	NN	Number=Sing	29	compound	29:compound	SpaceAfter=No

--- a/not-to-release/sources/answers/20111106210027AAhMxfE_ans.xml.conllu
+++ b/not-to-release/sources/answers/20111106210027AAhMxfE_ans.xml.conllu
@@ -13,8 +13,8 @@
 # sent_id = answers-20111106210027AAhMxfE_ans-0002
 # text = Can ssome oone please tell me where i can buy some weed in auckland.
 1	Can	can	AUX	MD	VerbForm=Fin	5	aux	5:aux	_
-2	ssome	ssome	DET	DT	_	3	det	3:det	_
-3	oone	oone	NOUN	NN	Number=Sing	5	nsubj	5:nsubj	_
+2	ssome	some	DET	DT	Typo=Yes	3	det	3:det	_
+3	oone	one	NOUN	NN	Number=Sing|Typo=Yes	5	nsubj	5:nsubj	_
 4	please	please	INTJ	UH	_	5	discourse	5:discourse	_
 5	tell	tell	VERB	VB	VerbForm=Inf	0	root	0:root	_
 6	me	I	PRON	PRP	Case=Acc|Number=Sing|Person=1|PronType=Prs	5	obj	5:obj	_

--- a/not-to-release/sources/answers/20111107211742AAHZaPe_ans.xml.conllu
+++ b/not-to-release/sources/answers/20111107211742AAHZaPe_ans.xml.conllu
@@ -769,7 +769,7 @@
 13	paid	pay	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	11	acl:relcl	11:acl:relcl	_
 14	about	about	ADV	RB	_	15	advmod	15:advmod	_
 15	800	800	NUM	CD	NumType=Card	13	obj	13:obj	SpaceAfter=No
-16	f	f	ADP	IN	_	19	case	19:case	_
+16	f	of	ADP	IN	Typo=Yes	19	case	19:case	_
 17	my	my	PRON	PRP$	Number=Sing|Person=1|Poss=Yes|PronType=Prs	19	nmod:poss	19:nmod:poss	_
 18	course	course	NOUN	NN	Number=Sing	19	compound	19:compound	_
 19	fees	fee	NOUN	NNS	Number=Plur	15	nmod	15:nmod	_

--- a/not-to-release/sources/answers/20111108050147AAOkFgL_ans.xml.conllu
+++ b/not-to-release/sources/answers/20111108050147AAOkFgL_ans.xml.conllu
@@ -26,7 +26,7 @@
 7	graduate	graduate	VERB	VB	VerbForm=Inf	5	xcomp	5:xcomp	_
 8	in	in	ADP	IN	_	12	case	12:case	_
 9	less	less	ADV	RBR	Degree=Cmp	12	case	12:case	_
-10	then	then	ADP	IN	_	12	nmod	12:nmod	_
+10	then	than	ADP	IN	Typo=Yes	12	nmod	12:nmod	_
 11	a	a	DET	DT	Definite=Ind|PronType=Art	12	nummod	12:nummod	_
 12	year	year	NOUN	NN	Number=Sing	7	obl	7:obl	SpaceAfter=No
 13	,	,	PUNCT	,	_	17	punct	17:punct	SpaceAfter=No
@@ -59,7 +59,7 @@
 15	want	want	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	7	conj	7:conj	_
 16	to	to	PART	TO	_	17	mark	17:mark	_
 17	go	go	VERB	VB	VerbForm=Inf	15	xcomp	15:xcomp	_
-18	aground	aground	ADP	IN	_	20	case	20:case	_
+18	aground	around	ADP	IN	Typo=Yes	20	case	20:case	_
 19	the	the	DET	DT	Definite=Def|PronType=Art	20	det	20:det	_
 20	world	world	NOUN	NN	Number=Sing	17	obl	17:obl	SpaceAfter=No
 21	,	,	PUNCT	,	_	25	punct	25:punct	SpaceAfter=No

--- a/not-to-release/sources/answers/20111108080049AAgT0iA_ans.xml.conllu
+++ b/not-to-release/sources/answers/20111108080049AAgT0iA_ans.xml.conllu
@@ -206,7 +206,7 @@
 10	scream	scream	VERB	VB	VerbForm=Inf	4	ccomp	4:ccomp	_
 11	after	after	ADP	IN	_	12	case	12:case	_
 12	her	she	PRON	PRP	Case=Acc|Gender=Fem|Number=Sing|Person=3|PronType=Prs	10	obl	10:obl	_
-13	of	of	CCONJ	CC	_	14	cc	14:cc	_
+13	of	or	CCONJ	CC	Typo=Yes	14	cc	14:cc	_
 14	anything	anything	PRON	NN	Number=Sing	10	conj	10:conj	SpaceAfter=No
 15	...	...	PUNCT	,	_	10	punct	10:punct	SpaceAfter=No
 16	he	he	PRON	PRP	Case=Nom|Gender=Masc|Number=Sing|Person=3|PronType=Prs	19	nsubj	19:nsubj	SpaceAfter=No

--- a/not-to-release/sources/answers/20111108082831AAco5PI_ans.xml.conllu
+++ b/not-to-release/sources/answers/20111108082831AAco5PI_ans.xml.conllu
@@ -668,7 +668,7 @@
 13	not	not	PART	RB	_	15	advmod	15:advmod	_
 14	her	she	PRON	PRP$	Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	15	nmod:poss	15:nmod:poss	_
 15	choice	choice	NOUN	NN	Number=Sing	3	conj	3:conj	_
-16	a	a	ADP	IN	_	18	case	18:case	_
+16	a	of	ADP	IN	Typo=Yes	18	case	18:case	_
 17	a	a	DET	DT	Definite=Ind|PronType=Art	18	det	18:det	_
 18	boyfriend	boyfriend	NOUN	NN	Number=Sing	15	nmod	15:nmod	_
 19	and	and	CCONJ	CC	_	22	cc	22:cc	_

--- a/not-to-release/sources/answers/20111108084416AAoPgBv_ans.xml.conllu
+++ b/not-to-release/sources/answers/20111108084416AAoPgBv_ans.xml.conllu
@@ -245,7 +245,7 @@
 4	Parisians	Parisians	PROPN	NNPS	Number=Plur	2	obj	2:obj	SpaceAfter=No
 5	,	,	PUNCT	,	_	2	punct	2:punct	_
 6	even	even	ADV	RB	_	8	advmod	8:advmod	_
-7	then	then	DET	DT	_	8	det	8:det	_
+7	then	the	DET	DT	Typo=Yes	8	det	8:det	_
 8	Parisians	Parisians	PROPN	NNPS	Number=Plur	11	nsubj	11:nsubj	_
 9	do	do	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	11	aux	11:aux	SpaceAfter=No
 10	n't	not	PART	RB	_	11	advmod	11:advmod	_

--- a/not-to-release/sources/answers/20111108084416AAoPgBv_ans.xml.conllu
+++ b/not-to-release/sources/answers/20111108084416AAoPgBv_ans.xml.conllu
@@ -58,11 +58,11 @@
 4	been	be	AUX	VBN	Tense=Past|VerbForm=Part	5	cop	5:cop	_
 5	anywhere	anywhere	ADV	RB	_	0	root	0:root	_
 6	out	out	X	GW	_	7	goeswith	7:goeswith	_
-7	side	side	ADP	IN	_	9	case	9:case	_
-8	my	my	PRON	PRP$	Number=Sing|Person=1|Poss=Yes|PronType=Prs	9	nmod:poss	9:nmod:poss	_
-9	home	home	NOUN	NN	Number=Sing	5	obl	5:obl	_
-10	town	town	ADP	IN	_	9	compound	9:compound	_
-11	Charlotte	Charlotte	PROPN	NNP	Number=Sing	9	appos	9:appos	_
+7	side	side	ADP	IN	_	10	case	10:case	_
+8	my	my	PRON	PRP$	Number=Sing|Person=1|Poss=Yes|PronType=Prs	10	nmod:poss	10:nmod:poss	_
+9	home	home	NOUN	NN	Number=Sing	10	compound	10:compound	_
+10	town	town	NOUN	NN	_	5	obl	5:obl	_
+11	Charlotte	Charlotte	PROPN	NNP	Number=Sing	10	appos	10:appos	_
 12	north	north	PROPN	NNP	Number=Sing	13	compound	13:compound	_
 13	Carolina	Carolina	PROPN	NNP	Number=Sing	11	appos	11:appos	_
 14	please	please	INTJ	UH	_	15	discourse	15:discourse	_

--- a/not-to-release/sources/answers/20111108090524AAofoXT_ans.xml.conllu
+++ b/not-to-release/sources/answers/20111108090524AAofoXT_ans.xml.conllu
@@ -133,7 +133,7 @@
 # sent_id = answers-20111108090524AAofoXT_ans-0007
 # text = Is that reasonable?
 1	Is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	3	cop	3:cop	_
-2	that	that	ADP	IN	_	3	nsubj	3:nsubj	_
+2	that	that	PRON	DT	_	3	nsubj	3:nsubj	_
 3	reasonable	reasonable	ADJ	JJ	Degree=Pos	0	root	0:root	SpaceAfter=No
 4	?	?	PUNCT	.	_	3	punct	3:punct	_
 
@@ -281,7 +281,7 @@
 21	travelling	travel	VERB	VBG	VerbForm=Ger	20	obj	20:obj	_
 22	hard	hard	ADJ	JJ	Degree=Pos	20	xcomp	20:xcomp	SpaceAfter=No
 23	,	,	PUNCT	,	_	22	punct	22:punct	_
-24	if	if	ADP	IN	_	27	mark	27:mark	_
+24	if	if	SCONJ	IN	_	27	mark	27:mark	_
 25	not	not	ADV	RB	_	27	advmod	27:advmod	_
 26	downright	downright	ADV	RB	_	27	advmod	27:advmod	_
 27	dangerous	dangerous	ADJ	JJ	Degree=Pos	22	advcl	22:advcl	SpaceAfter=No

--- a/not-to-release/sources/answers/20111108092029AAsHTYP_ans.xml.conllu
+++ b/not-to-release/sources/answers/20111108092029AAsHTYP_ans.xml.conllu
@@ -254,7 +254,7 @@
 4	darker	darker	ADJ	JJR	Degree=Cmp	0	root	0:root	_
 5	but	but	CCONJ	CC	_	6	cc	6:cc	_
 6	lighter	lighter	ADJ	JJR	Degree=Cmp	4	conj	4:conj	_
-7	then	then	ADP	IN	_	9	case	9:case	_
+7	then	than	ADP	IN	Typo=Yes	9	case	9:case	_
 8	the	the	DET	DT	Definite=Def|PronType=Art	9	det	9:det	_
 9	Silkies	silky	NOUN	NNS	Number=Plur	6	obl	6:obl	SpaceAfter=No
 10	.	.	PUNCT	.	_	4	punct	4:punct	_
@@ -466,7 +466,7 @@
 14	and	and	CCONJ	CC	_	16	cc	16:cc	_
 15	are	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	16	cop	16:cop	_
 16	smarter	smarter	ADJ	JJR	Degree=Cmp	8	conj	8:conj	_
-17	the	the	ADP	IN	_	18	case	18:case	_
+17	the	than	ADP	IN	Typo=Yes	18	case	18:case	_
 18	Silkies	silky	NOUN	NNS	Number=Plur	16	obl	16:obl	SpaceAfter=No
 19	.	.	PUNCT	.	_	2	punct	2:punct	_
 

--- a/not-to-release/sources/answers/20111108092643AAXe4lD_ans.xml.conllu
+++ b/not-to-release/sources/answers/20111108092643AAXe4lD_ans.xml.conllu
@@ -483,7 +483,7 @@
 18	to	to	ADP	IN	_	20	case	20:case	_
 19	the	the	DET	DT	Definite=Def|PronType=Art	20	det	20:det	_
 20	back	back	NOUN	NN	Number=Sing	17	obl	17:obl	_
-21	fo	fo	ADP	IN	_	23	case	23:case	_
+21	fo	of	ADP	IN	Typo=Yes	23	case	23:case	_
 22	the	the	DET	DT	Definite=Def|PronType=Art	23	det	23:det	_
 23	bird	bird	NOUN	NN	Number=Sing	20	nmod	20:nmod	SpaceAfter=No
 24	.	.	PUNCT	.	_	1	punct	1:punct	_

--- a/not-to-release/sources/answers/20111108093211AA8bYFE_ans.xml.conllu
+++ b/not-to-release/sources/answers/20111108093211AA8bYFE_ans.xml.conllu
@@ -62,7 +62,7 @@
 45	energetic	energetic	ADJ	JJ	Degree=Pos	42	ccomp	42:ccomp	_
 46	at	at	ADP	IN	_	47	case	47:case	_
 47	night	night	NOUN	NN	Number=Sing	45	obl	45:obl	_
-48	at	at	CCONJ	CC	_	54	cc	54:cc	_
+48	at	and	CCONJ	CC	Typo=Yes	54	cc	54:cc	_
 49	my	my	PRON	PRP$	Number=Sing|Person=1|Poss=Yes|PronType=Prs	50	nmod:poss	50:nmod:poss	_
 50	room	room	NOUN	NN	Number=Sing	54	nsubj	54:nsubj	_
 51	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	54	cop	54:cop	_

--- a/not-to-release/sources/answers/20111108100523AA1i7no_ans.xml.conllu
+++ b/not-to-release/sources/answers/20111108100523AA1i7no_ans.xml.conllu
@@ -168,7 +168,7 @@
 4	cage	cage	NOUN	NN	Number=Sing	0	root	0:root	_
 5	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	6	nsubj	6:nsubj	_
 6	have	have	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	4	acl:relcl	4:acl:relcl	_
-7	whhich	whhich	DET	WDT	PronType=Rel	11	nsubj	11:nsubj	_
+7	whhich	which	DET	WDT	PronType=Rel|Typo=Yes	11	nsubj	11:nsubj	_
 8	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	11	cop	11:cop	_
 9	pretty	pretty	ADV	RB	_	10	advmod	10:advmod	_
 10	much	much	ADV	RB	_	11	advmod	11:advmod	_

--- a/not-to-release/sources/answers/20111108101300AAIAKXN_ans.xml.conllu
+++ b/not-to-release/sources/answers/20111108101300AAIAKXN_ans.xml.conllu
@@ -158,7 +158,7 @@
 10	in	in	ADP	IN	_	12	case	12:case	_
 11	other	other	ADJ	JJ	Degree=Pos	12	amod	12:amod	_
 12	parts	part	NOUN	NNS	Number=Plur	9	obl	9:obl	_
-13	or	or	ADP	IN	_	14	case	14:case	_
+13	or	of	ADP	IN	Typo=Yes	14	case	14:case	_
 14	Japan	Japan	PROPN	NNP	Number=Sing	12	nmod	12:nmod	SpaceAfter=No
 15	,	,	PUNCT	,	_	9	punct	9:punct	_
 16	like	like	ADP	IN	_	17	case	17:case	_

--- a/not-to-release/sources/answers/20111108102445AA5mfrq_ans.xml.conllu
+++ b/not-to-release/sources/answers/20111108102445AA5mfrq_ans.xml.conllu
@@ -367,7 +367,7 @@
 4	Seville	Seville	PROPN	NNP	Number=Sing	2	nmod	2:nmod	_
 5	to	to	ADP	IN	_	6	case	6:case	_
 6	Barcelona	Barcelona	PROPN	NNP	Number=Sing	2	nmod	2:nmod	_
-7	an	an	CCONJ	CC	_	8	cc	8:cc	_
+7	an	and	CCONJ	CC	Typo=Yes	8	cc	8:cc	_
 8	Valencia	Valencia	PROPN	NNP	Number=Sing	6	conj	6:conj	SpaceAfter=No
 9	.	.	PUNCT	.	_	2	punct	2:punct	_
 

--- a/not-to-release/sources/answers/20111108102621AA3hPqj_ans.xml.conllu
+++ b/not-to-release/sources/answers/20111108102621AA3hPqj_ans.xml.conllu
@@ -86,8 +86,8 @@
 19	nt	not	PART	RB	_	20	advmod	20:advmod	_
 20	go	go	VERB	VB	VerbForm=Inf	3	parataxis	3:parataxis	_
 21	hard	hard	ADJ	JJ	Degree=Pos	20	xcomp	20:xcomp	_
-22	lik	lik	ADP	IN	_	24	case	24:case	_
-23	eneedle	eneedle	NOUN	NN	Number=Sing	24	obl:npmod	24:obl:npmod	_
+22	lik	like	ADP	IN	Typo=Yes	24	case	24:case	_
+23	eneedle	needle	NOUN	NN	Number=Sing|Typo=Yes	24	obl:npmod	24:obl:npmod	_
 24	hard	hard	ADJ	JJ	Degree=Pos	21	obl	21:obl	_
 25	but	but	CCONJ	CC	_	27	cc	27:cc	_
 26	they	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	27	nsubj	27:nsubj	_

--- a/not-to-release/sources/answers/20111108102810AAfCh1W_ans.xml.conllu
+++ b/not-to-release/sources/answers/20111108102810AAfCh1W_ans.xml.conllu
@@ -341,7 +341,7 @@
 9	lot	lot	NOUN	NN	Number=Sing	11	obl:npmod	11:obl:npmod	_
 10	like	like	SCONJ	IN	_	11	mark	11:mark	_
 11	watching	watch	VERB	VBG	VerbForm=Ger	0	root	0:root	_
-12	and	and	DET	DT	_	16	det	16:det	_
+12	and	a	DET	DT	Typo=Yes	16	det	16:det	_
 13	old	old	ADJ	JJ	Degree=Pos	16	amod	16:amod	_
 14	scratchy	scratchy	ADJ	JJ	Degree=Pos	16	amod	16:amod	_
 15	silent	silent	ADJ	JJ	Degree=Pos	16	amod	16:amod	_

--- a/not-to-release/sources/answers/20111108102900AA9qsc8_ans.xml.conllu
+++ b/not-to-release/sources/answers/20111108102900AA9qsc8_ans.xml.conllu
@@ -50,7 +50,7 @@
 5	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	7	nsubj	7:nsubj	_
 6	can	can	AUX	MD	VerbForm=Fin	7	aux	7:aux	_
 7	pick	pick	VERB	VB	VerbForm=Inf	4	parataxis	4:parataxis	_
-8	and	and	DET	DT	_	9	det	9:det	_
+8	and	a	DET	DT	Typo=Yes	9	det	9:det	_
 9	name	name	NOUN	NN	Number=Sing	7	obj	7:obj	_
 10	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	11	nsubj	11:nsubj	_
 11	want	want	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	9	acl:relcl	9:acl:relcl	_

--- a/not-to-release/sources/answers/20111108103333AA3eSCk_ans.xml.conllu
+++ b/not-to-release/sources/answers/20111108103333AA3eSCk_ans.xml.conllu
@@ -240,10 +240,10 @@
 
 # sent_id = answers-20111108103333AA3eSCk_ans-0014
 # text = Thi$ $ervice will co$t.
-1	Thi$	thi$	DET	DT	_	2	det	2:det	_
-2	$ervice	$ervice	NOUN	NN	Number=Sing	4	nsubj	4:nsubj	_
+1	Thi$	this	DET	DT	_	2	det	2:det	_
+2	$ervice	service	NOUN	NN	Number=Sing	4	nsubj	4:nsubj	_
 3	will	will	AUX	MD	VerbForm=Fin	4	aux	4:aux	_
-4	co$t	co$t	VERB	VB	VerbForm=Inf	0	root	0:root	SpaceAfter=No
+4	co$t	cost	VERB	VB	VerbForm=Inf	0	root	0:root	SpaceAfter=No
 5	.	.	PUNCT	.	_	4	punct	4:punct	_
 
 # sent_id = answers-20111108103333AA3eSCk_ans-0015

--- a/not-to-release/sources/answers/20111108103354AAQzdFB_ans.xml.conllu
+++ b/not-to-release/sources/answers/20111108103354AAQzdFB_ans.xml.conllu
@@ -228,11 +228,11 @@
 6	hand	hand	NOUN	NN	Number=Sing	4	obj	4:obj	_
 7	in	in	ADP	IN	_	9	case	9:case	_
 8	his	he	PRON	PRP$	Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	9	nmod:poss	9:nmod:poss	_
-9	cge	cge	NOUN	NN	Number=Sing	4	obl	4:obl	_
-10	ans	ans	CCONJ	CC	_	11	cc	11:cc	_
+9	cge	cage	NOUN	NN	Number=Sing|Typo=Yes	4	obl	4:obl	_
+10	ans	and	CCONJ	CC	Typo=Yes	11	cc	11:cc	_
 11	leave	leave	VERB	VB	Mood=Imp|VerbForm=Fin	4	conj	4:conj	_
 12	it	it	PRON	PRP	Case=Acc|Gender=Neut|Number=Sing|Person=3|PronType=Prs	11	obj	11:obj	_
-13	their	their	ADV	RB	_	11	advmod	11:advmod	SpaceAfter=No
+13	their	there	ADV	RB	Typo=Yes	11	advmod	11:advmod	SpaceAfter=No
 14	.	.	PUNCT	.	_	4	punct	4:punct	_
 
 # sent_id = answers-20111108103354AAQzdFB_ans-0013

--- a/not-to-release/sources/answers/20111108103704AAB0G7y_ans.xml.conllu
+++ b/not-to-release/sources/answers/20111108103704AAB0G7y_ans.xml.conllu
@@ -57,10 +57,10 @@
 2	pray	pray	VERB	VB	Mood=Imp|VerbForm=Fin	0	root	0:root	_
 3	for	for	ADP	IN	_	4	case	4:case	_
 4	her	she	PRON	PRP$	Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	2	obl	2:obl	_
-5	ad=nd	ad=nd	CCONJ	CC	_	6	cc	6:cc	_
+5	ad=nd	and	CCONJ	CC	Typo=Yes	6	cc	6:cc	_
 6	try	try	VERB	VB	Mood=Imp|VerbForm=Fin	2	conj	2:conj	_
 7	to	to	PART	TO	_	8	mark	8:mark	_
-8	hlep	hlep	VERB	VB	VerbForm=Inf	6	xcomp	6:xcomp	_
+8	hlep	help	VERB	VB	VerbForm=Inf|Typo=Yes	6	xcomp	6:xcomp	_
 9	your	you	PRON	PRP$	Person=2|Poss=Yes|PronType=Prs	10	nmod:poss	10:nmod:poss	_
 10	dog	dog	NOUN	NN	Number=Sing	8	obj	8:obj	_
 11	and	and	CCONJ	CC	_	12	cc	12:cc	_
@@ -92,7 +92,7 @@
 37	friends	friend	NOUN	NNS	Number=Plur	33	obl	33:obl	_
 38	and	and	CCONJ	CC	_	39	cc	39:cc	_
 39	family	family	NOUN	NN	Number=Sing	37	conj	37:conj	_
-40	adn	adn	CCONJ	CC	_	46	cc	46:cc	_
+40	adn	and	CCONJ	CC	Typo=Yes	46	cc	46:cc	_
 41	since	since	SCONJ	IN	_	45	mark	45:mark	_
 42	she	she	PRON	PRP	Case=Nom|Gender=Fem|Number=Sing|Person=3|PronType=Prs	45	nsubj	45:nsubj	SpaceAfter=No
 43	s	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	45	aux	45:aux	_

--- a/not-to-release/sources/answers/20111108104015AAGxHNm_ans.xml.conllu
+++ b/not-to-release/sources/answers/20111108104015AAGxHNm_ans.xml.conllu
@@ -150,7 +150,7 @@
 17	a	a	DET	DT	Definite=Ind|PronType=Art	19	det	19:det	_
 18	good	good	ADJ	JJ	Degree=Pos	19	amod	19:amod	_
 19	brand	brand	NOUN	NN	Number=Sing	14	ccomp	14:ccomp	_
-20	a	a	CCONJ	CC	_	22	cc	22:cc	_
+20	a	and	CCONJ	CC	Typo=Yes	22	cc	22:cc	_
 21	not	not	ADV	RB	_	22	advmod	22:advmod	_
 22	something	something	PRON	NN	Number=Sing	19	conj	19:conj	_
 23	like	like	ADP	IN	_	24	case	24:case	_

--- a/not-to-release/sources/answers/20111108104352AASs5OZ_ans.xml.conllu
+++ b/not-to-release/sources/answers/20111108104352AASs5OZ_ans.xml.conllu
@@ -170,7 +170,7 @@
 17	once	once	ADV	RB	NumType=Mult	10	advmod	10:advmod	_
 18	a	a	DET	DT	Definite=Ind|PronType=Art	19	det	19:det	_
 19	day	day	NOUN	NN	Number=Sing	17	obl:npmod	17:obl:npmod	_
-20	if	if	ADP	IN	_	22	mark	22:mark	_
+20	if	if	SCONJ	IN	_	22	mark	22:mark	_
 21	not	not	ADV	RB	_	22	advmod	22:advmod	_
 22	twice	twice	ADV	RB	NumType=Mult	17	advcl	17:advcl	SpaceAfter=No
 23	.	.	PUNCT	.	_	4	punct	4:punct	_

--- a/not-to-release/sources/answers/20111108104551AAVAVQR_ans.xml.conllu
+++ b/not-to-release/sources/answers/20111108104551AAVAVQR_ans.xml.conllu
@@ -398,7 +398,7 @@
 9	may	may	AUX	MD	VerbForm=Fin	10	aux	10:aux	_
 10	fight	fight	VERB	VB	VerbForm=Inf	4	conj	4:conj	_
 11	so	so	ADV	RB	_	16	advmod	16:advmod	_
-12	ther	ther	DET	DT	_	13	det	13:det	_
+12	ther	the	DET	DT	Typo=Yes	13	det	13:det	_
 13	smaller	smaller	ADJ	JJR	Degree=Cmp	16	nsubj	16:nsubj	_
 14	one	one	NUM	CD	NumType=Card	13	nummod	13:nummod	_
 15	can	can	AUX	MD	VerbForm=Fin	16	aux	16:aux	_

--- a/not-to-release/sources/answers/20111108104636AAw51HV_ans.xml.conllu
+++ b/not-to-release/sources/answers/20111108104636AAw51HV_ans.xml.conllu
@@ -68,8 +68,8 @@
 16	kollam	kollam	PROPN	NNP	Number=Sing	14	nmod	14:nmod	_
 17	@	@	SYM	SYM	_	19	case	19:case	_
 18	da	da	DET	DT	_	19	det	19:det	_
-19	syd	syd	NOUN	NN	Number=Sing	14	nmod	14:nmod	_
-20	f	f	ADP	IN	_	22	case	22:case	_
+19	syd	side	NOUN	NN	Number=Sing|Typo=Yes	14	nmod	14:nmod	_
+20	f	of	ADP	IN	Typo=Yes	22	case	22:case	_
 21	Ashtamudi	Ashtamudi	PROPN	NNP	Number=Sing	22	compound	22:compound	_
 22	Lake	Lake	PROPN	NNP	Number=Sing	19	nmod	19:nmod	_
 23	in	in	ADP	IN	_	24	case	24:case	_

--- a/not-to-release/sources/answers/20111108104724AAuBUR7_ans.xml.conllu
+++ b/not-to-release/sources/answers/20111108104724AAuBUR7_ans.xml.conllu
@@ -659,7 +659,7 @@
 18	spend	spend	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	24	advcl	24:advcl	_
 19	2	2	NUM	CD	NumType=Card	20	nummod	20:nummod	SpaceAfter=No
 20	K	k	NUM	CD	NumType=Card	18	obj	18:obj	_
-21	and	and	ADP	IN	_	22	case	22:case	_
+21	and	on	ADP	IN	Typo=Yes	22	case	22:case	_
 22	treatment	treatment	NOUN	NN	Number=Sing	18	obl	18:obl	_
 23	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	24	nsubj	24:nsubj	_
 24	come	come	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	4	conj	4:conj	_
@@ -1578,7 +1578,7 @@
 11	on	on	ADP	IN	_	13	case	13:case	_
 12	mile	mile	NOUN	NN	Number=Sing	13	compound	13:compound	_
 13	tracks	track	NOUN	NNS	Number=Plur	9	obl	9:obl	_
-14	then	then	ADP	IN	_	18	case	18:case	_
+14	then	than	ADP	IN	Typo=Yes	18	case	18:case	_
 15	1	1	NUM	CD	NumType=Card	17	compound	17:compound	SpaceAfter=No
 16	/	/	PUNCT	HYPH	_	17	punct	17:punct	SpaceAfter=No
 17	2	2	NUM	CD	NumType=Card	18	nummod	18:nummod	_

--- a/not-to-release/sources/answers/20111108110012AAK8Azy_ans.xml.conllu
+++ b/not-to-release/sources/answers/20111108110012AAK8Azy_ans.xml.conllu
@@ -442,7 +442,7 @@
 5	provide	provide	VERB	VB	VerbForm=Inf	2	xcomp	2:xcomp	_
 6	a	a	DET	DT	Definite=Ind|PronType=Art	7	det	7:det	_
 7	source	source	NOUN	NN	Number=Sing	5	obj	5:obj	_
-8	a	a	ADP	IN	_	10	case	10:case	_
+8	a	of	ADP	IN	Typo=Yes	10	case	10:case	_
 9	UVB	UVB	PROPN	NNP	Number=Sing	10	compound	10:compound	_
 10	lighting	lighting	NOUN	NN	Number=Sing	7	nmod	7:nmod	SpaceAfter=No
 11	.	.	PUNCT	.	_	2	punct	2:punct	_
@@ -773,7 +773,7 @@
 58	at	at	ADP	IN	_	60	case	60:case	_
 59	a	a	DET	DT	Definite=Ind|PronType=Art	60	det	60:det	_
 60	time	time	NOUN	NN	Number=Sing	53	nmod	53:nmod	_
-61	though	though	ADP	IN	_	67	advmod	67:advmod	_
+61	though	though	ADV	RB	_	67	advmod	67:advmod	_
 62	quite	quite	ADV	RB	_	63	advmod	63:advmod	_
 63	possibly	possibly	ADV	RB	_	67	advmod	67:advmod	_
 64	4	4	NUM	CD	NumType=Card	67	nummod	67:nummod	SpaceAfter=No

--- a/not-to-release/sources/answers/20111108111010AASEk0S_ans.xml.conllu
+++ b/not-to-release/sources/answers/20111108111010AASEk0S_ans.xml.conllu
@@ -312,7 +312,7 @@
 10	itself	itself	PRON	PRP	Case=Acc|Gender=Neut|Number=Sing|Person=3|PronType=Prs|Reflex=Yes	9	obj	9:obj	_
 11	put	put	VERB	VB	Mood=Imp|VerbForm=Fin	1	parataxis	1:parataxis	_
 12	something	something	PRON	NN	Number=Sing	11	obj	11:obj	_
-13	overt	overt	ADP	IN	_	14	case	14:case	_
+13	overt	over	ADP	IN	Typo=Yes	14	case	14:case	_
 14	it	it	PRON	PRP	Case=Acc|Gender=Neut|Number=Sing|Person=3|PronType=Prs	11	obl	11:obl	_
 15	like	like	ADP	IN	_	16	case	16:case	_
 16	newspaper	newspaper	NOUN	NN	Number=Sing	11	obl	11:obl	SpaceAfter=No

--- a/not-to-release/sources/answers/20111108111312AAq4ETn_ans.xml.conllu
+++ b/not-to-release/sources/answers/20111108111312AAq4ETn_ans.xml.conllu
@@ -275,7 +275,7 @@
 2	will	will	AUX	MD	VerbForm=Fin	3	aux	3:aux	_
 3	give	give	VERB	VB	VerbForm=Inf	0	root	0:root	_
 4	them	they	PRON	PRP	Case=Acc|Number=Plur|Person=3|PronType=Prs	3	iobj	3:iobj	_
-5	and	and	DET	DT	_	6	det	6:det	_
+5	and	a	DET	DT	Typo=Yes	6	det	6:det	_
 6	call	call	NOUN	NN	Number=Sing	3	obj	3:obj	_
 7	and	and	CCONJ	CC	_	8	cc	8:cc	_
 8	see	see	VERB	VB	VerbForm=Inf	3	conj	3:conj	_

--- a/not-to-release/sources/email/enronsent01_01.xml.conllu
+++ b/not-to-release/sources/email/enronsent01_01.xml.conllu
@@ -279,7 +279,7 @@
 19	and	and	CCONJ	CC	_	20	cc	20:cc	_
 20	type	type	VERB	VB	Mood=Imp|VerbForm=Fin	12	conj	12:conj	_
 21	in	in	ADV	RB	_	20	advmod	20:advmod	_
-22	unitedway.enron.com	unitedway.enron.com	ADP	RP	_	20	obj	20:obj	_
+22	unitedway.enron.com	unitedway.enron.com	X	ADD	_	20	obj	20:obj	_
 23	in	in	ADP	IN	_	26	case	26:case	_
 24	the	the	DET	DT	Definite=Def|PronType=Art	26	det	26:det	_
 25	address	address	NOUN	NN	Number=Sing	26	compound	26:compound	_

--- a/not-to-release/sources/email/enronsent10_01.xml.conllu
+++ b/not-to-release/sources/email/enronsent10_01.xml.conllu
@@ -301,7 +301,7 @@
 34	how	how	ADV	WRB	PronType=Int	36	advmod	36:advmod	_
 35	to	to	PART	TO	_	36	mark	36:mark	_
 36	access	access	VERB	VB	VerbForm=Inf	32	acl	32:acl	_
-37	teh	teh	DET	DT	_	39	det	39:det	_
+37	teh	the	DET	DT	Typo=Yes	39	det	39:det	_
 38	key	key	ADJ	JJ	Degree=Pos	39	amod	39:amod	_
 39	info.	info.	NOUN	NN	Number=Sing	36	obj	36:obj	_
 40	from	from	ADP	IN	_	41	case	41:case	_

--- a/not-to-release/sources/email/enronsent16_01.xml.conllu
+++ b/not-to-release/sources/email/enronsent16_01.xml.conllu
@@ -1290,7 +1290,7 @@
 4	Arco	Arco	PROPN	NNP	Number=Sing	5	compound	5:compound	_
 5	Products	Products	PROPN	NNPS	Number=Plur	0	root	0:root	SpaceAfter=No
 6	,	,	PUNCT	,	_	14	punct	14:punct	_
-7	adn	adn	CCONJ	CC	_	14	cc	14:cc	_
+7	adn	and	CCONJ	CC	Typo=Yes	14	cc	14:cc	_
 8	their	they	PRON	PRP$	Number=Plur|Person=3|Poss=Yes|PronType=Prs	9	nmod:poss	9:nmod:poss	_
 9	comments	comment	NOUN	NNS	Number=Plur	14	nsubj	14:nsubj	_
 10	are	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	14	cop	14:cop	_

--- a/not-to-release/sources/email/enronsent36_02.xml.conllu
+++ b/not-to-release/sources/email/enronsent36_02.xml.conllu
@@ -960,7 +960,7 @@
 5	the	the	DET	DT	Definite=Def|PronType=Art	7	det	7:det	_
 6	Prod	prod	NOUN	NN	Number=Sing	7	compound	7:compound	_
 7	Description	description	NOUN	NN	Number=Sing	4	obj	4:obj	_
-8	fro	fro	ADP	IN	_	11	case	11:case	_
+8	fro	for	ADP	IN	Typo=Yes	11	case	11:case	_
 9	the	the	DET	DT	Definite=Def|PronType=Art	11	det	11:det	_
 10	LME	lme	NOUN	NN	Number=Sing	11	compound	11:compound	_
 11	Product	product	NOUN	NN	Number=Sing	7	nmod	7:nmod	SpaceAfter=No

--- a/not-to-release/sources/email/enronsent42_01.xml.conllu
+++ b/not-to-release/sources/email/enronsent42_01.xml.conllu
@@ -1063,9 +1063,9 @@
 # sent_id = email-enronsent42_01-0077
 # text = Did dthat stuff form Joe help your car.
 1	Did	do	AUX	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	6	aux	6:aux	_
-2	dthat	dthat	DET	DT	_	3	det	3:det	_
+2	dthat	that	DET	DT	Typo=Yes	3	det	3:det	_
 3	stuff	stuff	NOUN	NN	Number=Sing	6	nsubj	6:nsubj	_
-4	form	form	ADP	IN	_	5	case	5:case	_
+4	form	from	ADP	IN	Typo=Yes	5	case	5:case	_
 5	Joe	Joe	PROPN	NNP	Number=Sing	3	nmod	3:nmod	_
 6	help	help	VERB	VB	VerbForm=Inf	0	root	0:root	_
 7	your	you	PRON	PRP$	Person=2|Poss=Yes|PronType=Prs	8	nmod:poss	8:nmod:poss	_

--- a/not-to-release/sources/email/enronsent44_01.xml.conllu
+++ b/not-to-release/sources/email/enronsent44_01.xml.conllu
@@ -1050,7 +1050,7 @@
 4	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	6	nsubj	6:nsubj	_
 5	can	can	AUX	MD	VerbForm=Fin	6	aux	6:aux	_
 6	wait	wait	VERB	VB	VerbForm=Inf	13	advcl	13:advcl	_
-7	til	til	ADP	IN	_	9	case	9:case	_
+7	til	till	ADP	IN	Typo=Yes	9	case	9:case	_
 8	2:00	2:00	NUM	CD	NumType=Card	9	nummod	9:nummod	SpaceAfter=No
 9	pm	pm	NOUN	NN	Number=Sing	6	obl	6:obl	_
 10	to	to	PART	TO	_	11	mark	11:mark	_

--- a/not-to-release/sources/newsgroup/groups.google.com_GUHarryPotterReaders_75faa7d55aff9230_ENG_20050715_234000.xml.conllu
+++ b/not-to-release/sources/newsgroup/groups.google.com_GUHarryPotterReaders_75faa7d55aff9230_ENG_20050715_234000.xml.conllu
@@ -66,6 +66,6 @@
 34	to	to	PART	TO	_	35	mark	35:mark	_
 35	learn	learn	VERB	VB	VerbForm=Inf	31	advcl	31:advcl	_
 36	more	more	ADJ	JJR	Degree=Cmp	35	obj	35:obj	_
-37	aboout	aboout	ADP	IN	_	38	case	38:case	_
+37	aboout	about	ADP	IN	Typo=Yes	38	case	38:case	_
 38	it	it	PRON	PRP	Case=Acc|Gender=Neut|Number=Sing|Person=3|PronType=Prs	36	obl	36:obl	_
 

--- a/not-to-release/sources/newsgroup/groups.google.com_GuildWars_086f0f64ab633ab3_ENG_20041111_173500.xml.conllu
+++ b/not-to-release/sources/newsgroup/groups.google.com_GuildWars_086f0f64ab633ab3_ENG_20041111_173500.xml.conllu
@@ -442,7 +442,7 @@
 5	a	a	DET	DT	Definite=Ind|PronType=Art	6	det	6:det	_
 6	doubt	doubt	NOUN	NN	Number=Sing	11	obl	11:obl	_
 7	the	the	DET	DT	Definite=Def|PronType=Art	11	reparandum	11:reparandum	_
-8	amoung	amoung	ADP	IN	_	11	case	11:case	_
+8	amoung	among	ADP	IN	Typo=Yes	11	case	11:case	_
 9	the	the	DET	DT	Definite=Def|PronType=Art	11	det	11:det	_
 10	best	best	ADJ	JJS	Degree=Sup	11	amod	11:amod	_
 11	graphics	graphic	NOUN	NNS	Number=Plur	0	root	0:root	_

--- a/not-to-release/sources/newsgroup/groups.google.com_alt.animals.bears_1125853b1f13cff6_ENG_20040126_171100.xml.conllu
+++ b/not-to-release/sources/newsgroup/groups.google.com_alt.animals.bears_1125853b1f13cff6_ENG_20040126_171100.xml.conllu
@@ -274,7 +274,7 @@
 8	the	the	DET	DT	Definite=Def|PronType=Art	9	det	9:det	_
 9	directions	direction	NOUN	NNS	Number=Plur	7	obj	7:obj	_
 10	exactly	exactly	ADV	RB	_	7	advmod	7:advmod	_
-11	that	that	ADP	IN	_	14	mark	14:mark	_
+11	that	then	ADV	RB	Typo=Yes	14	advmod	14:advmod	_
 12	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	14	nsubj	14:nsubj	_
 13	will	will	AUX	MD	VerbForm=Fin	14	aux	14:aux	_
 14	start	start	VERB	VB	VerbForm=Inf	2	ccomp	2:ccomp	_

--- a/not-to-release/sources/reviews/003418.xml.conllu
+++ b/not-to-release/sources/reviews/003418.xml.conllu
@@ -74,7 +74,7 @@
 4	no	no	DET	DT	_	5	det	5:det	_
 5	record	record	NOUN	NN	Number=Sing	3	obj	3:obj	_
 6	of	of	ADP	IN	_	8	case	8:case	_
-7	aa	aa	DET	DT	_	8	det	8:det	_
+7	aa	a	DET	DT	Typo=Yes	8	det	8:det	_
 8	reversal	reversal	NOUN	NN	Number=Sing	5	nmod	5:nmod	SpaceAfter=No
 9	.	.	PUNCT	.	_	3	punct	3:punct	_
 

--- a/not-to-release/sources/reviews/008635.xml.conllu
+++ b/not-to-release/sources/reviews/008635.xml.conllu
@@ -28,7 +28,7 @@
 3	value	value	NOUN	NN	Number=Sing	1	parataxis	1:parataxis	_
 4	wine	wine	NOUN	NN	Number=Sing	5	compound	5:compound	_
 5	list	list	NOUN	NN	Number=Sing	1	parataxis	1:parataxis	_
-6	to	to	ADV	RB	_	5	advmod	5:advmod	SpaceAfter=No
+6	to	too	ADV	RB	Typo=Yes	5	advmod	5:advmod	SpaceAfter=No
 7	.	.	PUNCT	.	_	5	punct	5:punct	_
 
 # sent_id = reviews-008635-0004

--- a/not-to-release/sources/reviews/018548.xml.conllu
+++ b/not-to-release/sources/reviews/018548.xml.conllu
@@ -90,7 +90,7 @@
 2	cuts	cut	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 3	down	down	ADP	RP	_	2	compound:prt	2:compound:prt	_
 4	on	on	ADP	IN	_	7	case	7:case	_
-5	teh	teh	DET	DT	_	7	det	7:det	_
+5	teh	the	DET	DT	Typo=Yes	7	det	7:det	_
 6	wait	wait	NOUN	NN	Number=Sing	7	compound	7:compound	_
 7	time	time	NOUN	NN	Number=Sing	2	obl	2:obl	SpaceAfter=No
 8	,	,	PUNCT	,	_	2	punct	2:punct	_

--- a/not-to-release/sources/reviews/023620.xml.conllu
+++ b/not-to-release/sources/reviews/023620.xml.conllu
@@ -30,7 +30,7 @@
 2	though	though	SCONJ	IN	_	5	mark	5:mark	_
 3	they	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	5	nsubj	5:nsubj	_
 4	still	still	ADV	RB	_	5	advmod	5:advmod	_
-5	charge	charge	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	17	advcl	17:advcl	_
+5	charge	charge	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	18	advcl	18:advcl	_
 6	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	5	iobj	5:iobj	_
 7	the	the	DET	DT	Definite=Def|PronType=Art	8	det	8:det	_
 8	days	day	NOUN	NNS	Number=Plur	5	obj	5:obj	_
@@ -40,12 +40,12 @@
 12	wo	will	AUX	MD	VerbForm=Fin	14	aux	14:aux	SpaceAfter=No
 13	n't	not	PART	RB	_	14	advmod	14:advmod	_
 14	use	use	VERB	VB	VerbForm=Inf	10	conj	10:conj	SpaceAfter=No
-15	,	,	PUNCT	,	_	17	punct	17:punct	_
-16	it	it	PRON	PRP	Case=Nom|Gender=Neut|Number=Sing|Person=3|PronType=Prs	17	expl	17:expl	_
-17	is	be	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	_
-18	worth	worth	ADP	IN	_	19	case	19:case	_
-19	the	the	DET	DT	Definite=Def|PronType=Art	17	obl	17:obl	_
-20	get	get	VERB	VB	VerbForm=Inf	17	dep	17:dep	_
+15	,	,	PUNCT	,	_	18	punct	18:punct	_
+16	it	it	PRON	PRP	Case=Nom|Gender=Neut|Number=Sing|Person=3|PronType=Prs	18	expl	18:expl	_
+17	is	be	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	18	cop	18:cop	_
+18	worth	worth	ADJ	JJ	Degree=Pos	0	root	0:root	_
+19	the	the	DET	DT	Definite=Def|PronType=Art	18	obj	18:obj	_
+20	get	get	VERB	VB	VerbForm=Inf	18	csubj	18:csubj	_
 21	the	the	DET	DT	Definite=Def|PronType=Art	22	det	22:det	_
 22	hell	hell	NOUN	NN	Number=Sing	20	obl:npmod	20:obl:npmod	_
 23	out	out	ADP	IN	_	27	case	27:case	_
@@ -53,7 +53,7 @@
 25	this	this	DET	DT	Number=Sing|PronType=Dem	27	det	27:det	_
 26	crap	crap	NOUN	NN	Number=Sing	27	compound	27:compound	_
 27	hole	hole	NOUN	NN	Number=Sing	20	obl	20:obl	SpaceAfter=No
-28	.	.	PUNCT	.	_	17	punct	17:punct	_
+28	.	.	PUNCT	.	_	18	punct	18:punct	_
 
 # sent_id = reviews-023620-0003
 # text = The whole experience shows a hotel managed by what must be a 2 star hotel manager.

--- a/not-to-release/sources/reviews/035726.xml.conllu
+++ b/not-to-release/sources/reviews/035726.xml.conllu
@@ -54,7 +54,7 @@
 # text = She is and excellent doctor to have on one's team.
 1	She	she	PRON	PRP	Case=Nom|Gender=Fem|Number=Sing|Person=3|PronType=Prs	5	nsubj	5:nsubj	_
 2	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	5	cop	5:cop	_
-3	and	and	DET	DT	_	5	det	5:det	_
+3	and	a	DET	DT	Typo=Yes	5	det	5:det	_
 4	excellent	excellent	ADJ	JJ	Degree=Pos	5	amod	5:amod	_
 5	doctor	doctor	NOUN	NN	Number=Sing	0	root	0:root	_
 6	to	to	PART	TO	_	7	mark	7:mark	_

--- a/not-to-release/sources/reviews/035726.xml.conllu
+++ b/not-to-release/sources/reviews/035726.xml.conllu
@@ -32,7 +32,7 @@
 3	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	5	cop	5:cop	_
 4	very	very	ADV	RB	_	5	advmod	5:advmod	_
 5	kind	kind	ADJ	JJ	Degree=Pos	0	root	0:root	_
-6	an	an	CCONJ	CC	_	7	cc	7:cc	_
+6	an	and	CCONJ	CC	Typo=Yes	7	cc	7:cc	_
 7	gentle	gentle	ADJ	JJ	Degree=Pos	5	conj	5:conj	_
 8	with	with	ADP	IN	_	10	case	10:case	_
 9	the	the	DET	DT	Definite=Def|PronType=Art	10	det	10:det	_

--- a/not-to-release/sources/reviews/070730.xml.conllu
+++ b/not-to-release/sources/reviews/070730.xml.conllu
@@ -31,7 +31,7 @@
 28	scallop	scallop	NOUN	NN	Number=Sing	29	compound	29:compound	_
 29	sashimi	sashimi	NOUN	NN	Number=Sing	14	obj	14:obj	SpaceAfter=No
 30	,	,	PUNCT	,	_	29	punct	29:punct	_
-31	duck	duck	ADP	IN	_	32	compound	32:compound	_
+31	duck	duck	NOUN	NN	_	32	compound	32:compound	_
 32	breast	breast	NOUN	NN	Number=Sing	33	compound	33:compound	_
 33	nigiri	nigiri	NOUN	NN	Number=Sing	29	appos	29:appos	_
 34	with	with	ADP	IN	_	36	case	36:case	_

--- a/not-to-release/sources/reviews/071650.xml.conllu
+++ b/not-to-release/sources/reviews/071650.xml.conllu
@@ -135,7 +135,7 @@
 6	-	-	PUNCT	,	_	1	punct	1:punct	_
 7	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	9	nsubj:pass	9:nsubj:pass	_
 8	was	be	AUX	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	9	aux:pass	9:aux:pass	_
-9	excepted	except	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	1	parataxis	1:parataxis	_
+9	excepted	accept	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass|Typo=Yes	1	parataxis	1:parataxis	_
 10	to	to	ADP	IN	_	12	case	12:case	_
 11	medical	medical	ADJ	JJ	Degree=Pos	12	amod	12:amod	_
 12	school	school	NOUN	NN	Number=Sing	9	obl	9:obl	_

--- a/not-to-release/sources/reviews/100592.xml.conllu
+++ b/not-to-release/sources/reviews/100592.xml.conllu
@@ -17,7 +17,7 @@
 # text = yep they fixeded my thumpstar in 1 day.
 1	yep	yep	INTJ	UH	_	3	discourse	3:discourse	_
 2	they	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	3	nsubj	3:nsubj	_
-3	fixeded	fixede	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+3	fixeded	fixed	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin|Typo=Yes	0	root	0:root	_
 4	my	my	PRON	PRP$	Number=Sing|Person=1|Poss=Yes|PronType=Prs	5	nmod:poss	5:nmod:poss	_
 5	thumpstar	thumpstar	PROPN	NNP	Number=Sing	3	obj	3:obj	_
 6	in	in	ADP	IN	_	8	case	8:case	_
@@ -28,10 +28,10 @@
 # sent_id = reviews-100592-0003
 # text = it wasent going an had a gear box problem....
 1	it	it	PRON	PRP	Case=Nom|Gender=Neut|Number=Sing|Person=3|PronType=Prs	4	nsubj	4:nsubj	_
-2	wase	wase	AUX	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	4	aux	4:aux	SpaceAfter=No
+2	wase	was	AUX	VBD	Mood=Ind|Tense=Past|VerbForm=Fin|Typo=Yes	4	aux	4:aux	SpaceAfter=No
 3	nt	not	PART	RB	_	4	advmod	4:advmod	_
 4	going	go	VERB	VBG	VerbForm=Ger	0	root	0:root	_
-5	an	an	CCONJ	CC	_	6	cc	6:cc	_
+5	an	and	CCONJ	CC	Typo=Yes	6	cc	6:cc	_
 6	had	have	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	4	conj	4:conj	_
 7	a	a	DET	DT	Definite=Ind|PronType=Art	10	det	10:det	_
 8	gear	gear	NOUN	NN	Number=Sing	9	compound	9:compound	_
@@ -42,7 +42,7 @@
 # sent_id = reviews-100592-0004
 # text = i coldn't find anywere else local to fix it so i took it there and they fixed it for $150...
 1	i	i	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	4	nsubj	4:nsubj	_
-2	cold	cold	AUX	MD	VerbForm=Fin	4	aux	4:aux	SpaceAfter=No
+2	cold	could	AUX	MD	VerbForm=Fin|Typo=Yes	4	aux	4:aux	SpaceAfter=No
 3	n't	not	PART	RB	_	4	advmod	4:advmod	_
 4	find	find	VERB	VB	VerbForm=Inf	0	root	0:root	_
 5	anywere	anywere	NOUN	NN	Number=Sing	4	obj	4:obj	_
@@ -73,7 +73,7 @@
 4	really	really	ADV	RB	_	5	advmod	5:advmod	_
 5	well	well	ADV	RB	Degree=Pos	3	advmod	3:advmod	_
 6	and	and	CCONJ	CC	_	7	cc	7:cc	_
-7	thaks	thaks	NOUN	NN	Number=Sing	1	conj	1:conj	_
+7	thaks	thanks	NOUN	NN	Number=Sing|Typo=Yes	1	conj	1:conj	_
 8	4	4	ADP	IN	_	11	case	11:case	_
 9	the	the	DET	DT	Definite=Def|PronType=Art	11	det	11:det	_
 10	cheap	cheap	ADJ	JJ	Degree=Pos	11	amod	11:amod	_
@@ -88,7 +88,7 @@
 4	guys	guy	NOUN	NNS	Number=Plur	1	list	1:list	_
 5	a	a	NOUN	NN	Number=Sing	1	list	1:list	SpaceAfter=No
 6	+++++	+++++	SYM	SYM	_	5	compound	5:compound	_
-7	reccommend	reccommend	VERB	VB	VerbForm=Inf	1	list	1:list	_
+7	reccommend	recommend	VERB	VB	VerbForm=Inf|Typo=Yes	1	list	1:list	_
 8	to	to	ADP	IN	_	9	case	9:case	_
 9	anyone	anyone	PRON	NN	Number=Sing	7	obl	7:obl	SpaceAfter=No
 10	!!!!!!!!!!	!!!!!!!!!!	PUNCT	.	_	4	punct	4:punct	_

--- a/not-to-release/sources/reviews/115653.xml.conllu
+++ b/not-to-release/sources/reviews/115653.xml.conllu
@@ -42,7 +42,7 @@
 13	walk	walk	VERB	VB	VerbForm=Inf	9	acl:relcl	9:acl:relcl	_
 14	or	or	CCONJ	CC	_	16	cc	16:cc	_
 15	even	even	ADV	RB	_	16	advmod	16:advmod	_
-16	bare	bare	VERB	VB	VerbForm=Inf	13	conj	13:conj	_
+16	bare	bear	VERB	VB	VerbForm=Inf|Typo=Yes	13	conj	13:conj	_
 17	to	to	PART	TO	_	18	mark	18:mark	_
 18	sit	sit	VERB	VB	VerbForm=Inf	16	xcomp	16:xcomp	SpaceAfter=No
 19	.	.	PUNCT	.	_	3	punct	3:punct	_

--- a/not-to-release/sources/reviews/118718.xml.conllu
+++ b/not-to-release/sources/reviews/118718.xml.conllu
@@ -28,10 +28,10 @@
 # text = They were accomdating with my scheduled and work with my insurance to get payment for the surgery.
 1	They	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	3	nsubj	3:nsubj	_
 2	were	be	AUX	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	3	cop	3:cop	_
-3	accomdating	accomdating	ADJ	JJ	Degree=Pos	0	root	0:root	_
+3	accomdating	accommodating	ADJ	JJ	Degree=Pos|Typo=Yes	0	root	0:root	_
 4	with	with	ADP	IN	_	6	case	6:case	_
 5	my	my	PRON	PRP$	Number=Sing|Person=1|Poss=Yes|PronType=Prs	6	nmod:poss	6:nmod:poss	_
-6	scheduled	scheduled	NOUN	NN	Number=Sing	3	obl	3:obl	_
+6	scheduled	schedule	NOUN	NN	Number=Sing|Typo=Yes	3	obl	3:obl	_
 7	and	and	CCONJ	CC	_	8	cc	8:cc	_
 8	work	work	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	3	conj	3:conj	_
 9	with	with	ADP	IN	_	11	case	11:case	_

--- a/not-to-release/sources/reviews/120724.xml.conllu
+++ b/not-to-release/sources/reviews/120724.xml.conllu
@@ -5,7 +5,7 @@
 2	was	be	AUX	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	7	cop	7:cop	_
 3	a	a	DET	DT	Definite=Ind|PronType=Art	4	det	4:det	_
 4	little	little	NOUN	NN	Number=Sing	5	advmod	5:advmod	_
-5	to	to	ADV	RB	_	6	advmod	6:advmod	_
+5	to	too	ADV	RB	Typo=Yes	6	advmod	6:advmod	_
 6	high	high	ADJ	JJ	Degree=Pos	7	amod	7:amod	_
 7	dollar	dollar	NOUN	NN	Number=Sing	0	root	0:root	_
 8	for	for	ADP	IN	_	9	case	9:case	_

--- a/not-to-release/sources/reviews/126171.xml.conllu
+++ b/not-to-release/sources/reviews/126171.xml.conllu
@@ -48,7 +48,7 @@
 5	to	to	PART	TO	_	6	mark	6:mark	_
 6	come	come	VERB	VB	VerbForm=Inf	4	xcomp	4:xcomp	_
 7	across	across	ADV	RB	_	6	advmod	6:advmod	_
-8	and	and	ADP	IN	_	9	case	9:case	_
+8	and	as	ADP	IN	Typo=Yes	9	case	9:case	_
 9	professional	professional	ADJ	JJ	Degree=Pos	6	obl	6:obl	_
 10	and	and	CCONJ	CC	_	11	cc	11:cc	_
 11	nice	nice	ADJ	JJ	Degree=Pos	9	conj	9:conj	SpaceAfter=No

--- a/not-to-release/sources/reviews/131458.xml.conllu
+++ b/not-to-release/sources/reviews/131458.xml.conllu
@@ -68,7 +68,7 @@
 14	that	that	SCONJ	IN	_	17	mark	17:mark	_
 15	she	she	PRON	PRP	Case=Nom|Gender=Fem|Number=Sing|Person=3|PronType=Prs	17	nsubj	17:nsubj	_
 16	will	will	AUX	MD	VerbForm=Fin	17	aux	17:aux	_
-17	endevour	endevour	VERB	VB	VerbForm=Inf	13	ccomp	13:ccomp	_
+17	endevour	endeavor	VERB	VB	VerbForm=Inf|Typo=Yes	13	ccomp	13:ccomp	_
 18	to	to	PART	TO	_	19	mark	19:mark	_
 19	satisfy	satisfy	VERB	VB	VerbForm=Inf	17	xcomp	17:xcomp	_
 20	all	all	DET	PDT	_	23	det:predet	23:det:predet	_

--- a/not-to-release/sources/reviews/158285.xml.conllu
+++ b/not-to-release/sources/reviews/158285.xml.conllu
@@ -14,7 +14,7 @@
 11	price	price	NOUN	NN	Number=Sing	15	nsubj	15:nsubj	_
 12	was	be	AUX	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	15	cop	15:cop	_
 13	way	way	ADV	RB	_	15	advmod	15:advmod	_
-14	to	to	ADV	RB	_	15	advmod	15:advmod	_
+14	to	too	ADV	RB	Typo=Yes	15	advmod	15:advmod	_
 15	high	high	ADJ	JJ	Degree=Pos	5	list	5:list	_
 16	for	for	ADP	IN	_	17	case	17:case	_
 17	Duluth	Duluth	PROPN	NNP	Number=Sing	15	obl	15:obl	_

--- a/not-to-release/sources/reviews/169083.xml.conllu
+++ b/not-to-release/sources/reviews/169083.xml.conllu
@@ -6,7 +6,7 @@
 3	been	be	AUX	VBN	Tense=Past|VerbForm=Part	5	cop	5:cop	_
 4	a	a	DET	DT	Definite=Ind|PronType=Art	5	det	5:det	_
 5	patient	patient	NOUN	NN	Number=Sing	0	root	0:root	_
-6	a	a	ADP	IN	_	8	case	8:case	_
+6	a	at	ADP	IN	Typo=Yes	8	case	8:case	_
 7	NW	NW	PROPN	NNP	Number=Sing	8	compound	8:compound	_
 8	hospital	hospital	NOUN	NN	Number=Sing	5	nmod	5:nmod	_
 9	and	and	CCONJ	CC	_	12	cc	12:cc	_

--- a/not-to-release/sources/reviews/192713.xml.conllu
+++ b/not-to-release/sources/reviews/192713.xml.conllu
@@ -90,7 +90,7 @@
 9	have	have	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	11	aux	11:aux	_
 10	ever	ever	ADV	RB	_	11	advmod	11:advmod	_
 11	been	be	VERB	VBN	Tense=Past|VerbForm=Part	7	acl:relcl	7:acl:relcl	_
-12	too	too	ADP	IN	_	11	obl	11:obl	SpaceAfter=No
+12	too	to	ADP	IN	Typo=Yes	11	obl	11:obl	SpaceAfter=No
 13	.	.	PUNCT	.	_	3	punct	3:punct	_
 
 # sent_id = reviews-192713-0007

--- a/not-to-release/sources/reviews/220214.xml.conllu
+++ b/not-to-release/sources/reviews/220214.xml.conllu
@@ -102,7 +102,7 @@
 29	two	two	NUM	CD	NumType=Card	30	nummod	30:nummod	_
 30	things	thing	NOUN	NNS	Number=Plur	27	obj	27:obj	_
 31	in	in	ADP	IN	_	32	case	32:case	_
-32	particlular	particlular	ADJ	JJ	Degree=Pos	27	obl	27:obl	SpaceAfter=No
+32	particlular	particular	ADJ	JJ	Degree=Pos|Typo=Yes	27	obl	27:obl	SpaceAfter=No
 33	.	.	PUNCT	.	_	2	punct	2:punct	_
 
 # sent_id = reviews-220214-0005

--- a/not-to-release/sources/reviews/223912.xml.conllu
+++ b/not-to-release/sources/reviews/223912.xml.conllu
@@ -15,7 +15,7 @@
 12	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	14	nsubj	14:nsubj	SpaceAfter=No
 13	r	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	14	aux	14:aux	_
 14	looking	look	VERB	VBG	VerbForm=Ger	27	advcl	27:advcl	_
-15	fot	fot	ADP	IN	_	18	case	18:case	_
+15	fot	for	ADP	IN	Typo=Yes	18	case	18:case	_
 16	a	a	DET	DT	Definite=Ind|PronType=Art	18	det	18:det	_
 17	good	good	ADJ	JJ	Degree=Pos	18	amod	18:amod	_
 18	game	game	NOUN	NN	Number=Sing	14	obl	14:obl	_

--- a/not-to-release/sources/reviews/228944.xml.conllu
+++ b/not-to-release/sources/reviews/228944.xml.conllu
@@ -63,6 +63,6 @@
 8	take	take	VERB	VB	VerbForm=Inf	5	acl:relcl	5:acl:relcl	_
 9	my	my	PRON	PRP$	Number=Sing|Person=1|Poss=Yes|PronType=Prs	10	nmod:poss	10:nmod:poss	_
 10	car	car	NOUN	NN	Number=Sing	8	obj	8:obj	_
-11	peiod	peiod	NOUN	NN	Number=Sing	8	obl:npmod	8:obl:npmod	SpaceAfter=No
+11	peiod	period	NOUN	NN	Number=Sing|Typo=Yes	8	obl:npmod	8:obl:npmod	SpaceAfter=No
 12	.	.	PUNCT	.	_	5	punct	5:punct	_
 

--- a/not-to-release/sources/reviews/245160.xml.conllu
+++ b/not-to-release/sources/reviews/245160.xml.conllu
@@ -79,7 +79,7 @@
 10	right	right	ADJ	JJ	Degree=Pos	11	amod	11:amod	_
 11	car	car	NOUN	NN	Number=Sing	8	obj	8:obj	_
 12	rather	rather	ADV	RB	_	15	cc	15:cc	_
-13	then	then	ADP	IN	_	12	fixed	12:fixed	_
+13	then	than	ADP	IN	Typo=Yes	12	fixed	12:fixed	_
 14	just	just	ADV	RB	_	15	advmod	15:advmod	_
 15	make	make	VERB	VB	VerbForm=Inf	6	conj	6:conj	_
 16	a	a	DET	DT	Definite=Ind|PronType=Art	17	det	17:det	_

--- a/not-to-release/sources/reviews/249123.xml.conllu
+++ b/not-to-release/sources/reviews/249123.xml.conllu
@@ -70,7 +70,7 @@
 10	out	out	ADP	IN	_	12	case	12:case	_
 11	the	the	DET	DT	Definite=Def|PronType=Art	12	det	12:det	_
 12	door	door	NOUN	NN	Number=Sing	9	obl	9:obl	_
-13	that	that	ADP	IN	_	15	advmod	15:advmod	_
+13	that	that	SCONJ	IN	_	15	mark	15:mark	_
 14	someone	someone	PRON	NN	Number=Sing	15	nsubj	15:nsubj	_
 15	asked	ask	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	2	csubj	2:csubj	_
 16	Can	can	AUX	MD	VerbForm=Fin	18	aux	18:aux	_

--- a/not-to-release/sources/reviews/267793.xml.conllu
+++ b/not-to-release/sources/reviews/267793.xml.conllu
@@ -20,7 +20,7 @@
 12	way	way	ADV	RB	_	14	advmod	14:advmod	_
 13	more	more	ADV	RBR	_	14	advmod	14:advmod	_
 14	effective	effective	ADJ	JJ	Degree=Pos	3	conj	3:conj	_
-15	that	that	ADP	IN	_	18	case	18:case	_
+15	that	than	ADP	IN	Typo=Yes	18	case	18:case	_
 16	a	a	DET	DT	Definite=Ind|PronType=Art	18	det	18:det	_
 17	regular	regular	ADJ	JJ	Degree=Pos	18	amod	18:amod	_
 18	doctor	doctor	NOUN	NN	Number=Sing	13	obl	13:obl	SpaceAfter=No

--- a/not-to-release/sources/reviews/269560.xml.conllu
+++ b/not-to-release/sources/reviews/269560.xml.conllu
@@ -53,7 +53,7 @@
 # sent_id = reviews-269560-0002
 # text = He preceded to grab the slice off the countertop and throw it into the trash while yelling at me saying, "you do not order what you do not know about" and "you don't know how pizza is made".
 1	He	he	PRON	PRP	Case=Nom|Gender=Masc|Number=Sing|Person=3|PronType=Prs	2	nsubj	2:nsubj	_
-2	preceded	precede	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+2	preceded	proceed	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin|Typo=Yes	0	root	0:root	_
 3	to	to	PART	TO	_	4	mark	4:mark	_
 4	grab	grab	VERB	VB	VerbForm=Inf	2	xcomp	2:xcomp	_
 5	the	the	DET	DT	Definite=Def|PronType=Art	6	det	6:det	_

--- a/not-to-release/sources/reviews/274106.xml.conllu
+++ b/not-to-release/sources/reviews/274106.xml.conllu
@@ -72,7 +72,7 @@
 2	Food	food	NOUN	NN	Number=Sing	4	nsubj	4:nsubj	_
 3	was	be	AUX	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	4	cop	4:cop	_
 4	better	better	ADJ	JJR	Degree=Cmp	0	root	0:root	_
-5	then	then	ADP	IN	_	6	case	6:case	_
+5	then	than	ADP	IN	Typo=Yes	6	case	6:case	_
 6	anything	anything	PRON	NN	Number=Sing	4	obl	4:obl	_
 7	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	10	nsubj	10:nsubj	_
 8	had	have	AUX	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	10	aux	10:aux	_

--- a/not-to-release/sources/reviews/295491.xml.conllu
+++ b/not-to-release/sources/reviews/295491.xml.conllu
@@ -2,7 +2,7 @@
 # sent_id = reviews-295491-0001
 # text = Skip te rest - this is the best
 1	Skip	skip	VERB	VB	Mood=Imp|VerbForm=Fin	0	root	0:root	_
-2	te	te	DET	DT	_	3	det	3:det	_
+2	te	the	DET	DT	Typo=Yes	3	det	3:det	_
 3	rest	rest	NOUN	NN	Number=Sing	1	obj	1:obj	_
 4	-	-	PUNCT	,	_	1	punct	1:punct	_
 5	this	this	PRON	DT	Number=Sing|PronType=Dem	8	nsubj	8:nsubj	_

--- a/not-to-release/sources/reviews/307170.xml.conllu
+++ b/not-to-release/sources/reviews/307170.xml.conllu
@@ -15,8 +15,8 @@
 1	Great	Great	PROPN	NNP	Number=Sing	3	compound	3:compound	_
 2	Limos	Limos	PROPN	NNP	Number=Sing	3	compound	3:compound	_
 3	company	company	NOUN	NN	Number=Sing	0	root	0:root	_
-4	int	int	ADP	IN	_	10	case	10:case	_
-5	he	he	DET	DT	_	10	det	10:det	_
+4	int	in	ADP	IN	Typo=Yes	10	case	10:case	_
+5	he	the	DET	DT	Typo=Yes	10	det	10:det	_
 6	DFW	DFW	PROPN	NNP	Number=Sing	8	compound	8:compound	_
 7	fort	fort	PROPN	NNP	Number=Sing	8	compound	8:compound	_
 8	Worth	Worth	PROPN	NNP	Number=Sing	10	compound	10:compound	_

--- a/not-to-release/sources/reviews/336049.xml.conllu
+++ b/not-to-release/sources/reviews/336049.xml.conllu
@@ -183,7 +183,7 @@
 14	to	to	PART	TO	_	15	mark	15:mark	_
 15	rub	rub	VERB	VB	VerbForm=Inf	9	advcl	9:advcl	_
 16	it	it	PRON	PRP	Case=Acc|Gender=Neut|Number=Sing|Person=3|PronType=Prs	15	obj	15:obj	_
-17	it	it	ADP	RP	_	15	compound:prt	15:compound:prt	SpaceAfter=No
+17	it	in	ADP	RP	Typo=Yes	15	compound:prt	15:compound:prt	SpaceAfter=No
 18	....	....	PUNCT	.	_	7	punct	7:punct	_
 
 # sent_id = reviews-336049-0007

--- a/not-to-release/sources/reviews/345182.xml.conllu
+++ b/not-to-release/sources/reviews/345182.xml.conllu
@@ -245,7 +245,7 @@
 3	me	I	PRON	PRP	Case=Acc|Number=Sing|Person=1|PronType=Prs	2	obj	2:obj	_
 4	that	that	PRON	DT	Number=Sing|PronType=Dem	7	nsubj	7:nsubj	_
 5	was	be	AUX	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	7	cop	7:cop	_
-6	to	to	ADV	RB	_	7	advmod	7:advmod	_
+6	to	too	ADV	RB	Typo=Yes	7	advmod	7:advmod	_
 7	bad	bad	ADJ	JJ	Degree=Pos	2	ccomp	2:ccomp	_
 8	she	she	PRON	PRP	Case=Nom|Gender=Fem|Number=Sing|Person=3|PronType=Prs	10	nsubj	10:nsubj	_
 9	would	would	AUX	MD	VerbForm=Fin	10	aux	10:aux	_
@@ -324,7 +324,7 @@
 # text = There are to many people that need our business to have to put up with this unfair treatment!!!!!
 1	There	there	PRON	EX	_	2	expl	2:expl	_
 2	are	be	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
-3	to	to	ADV	RB	_	4	advmod	4:advmod	_
+3	to	too	ADV	RB	Typo=Yes	4	advmod	4:advmod	_
 4	many	many	ADJ	JJ	Degree=Pos	5	amod	5:amod	_
 5	people	people	NOUN	NNS	Number=Plur	2	nsubj	2:nsubj	_
 6	that	that	PRON	WDT	PronType=Rel	7	nsubj	7:nsubj	_

--- a/not-to-release/sources/reviews/348369.xml.conllu
+++ b/not-to-release/sources/reviews/348369.xml.conllu
@@ -56,7 +56,7 @@
 2	want	want	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 3	to	to	PART	TO	_	4	mark	4:mark	_
 4	Send	send	VERB	VB	VerbForm=Inf	2	xcomp	2:xcomp	_
-5	of	of	ADP	RP	_	4	compound:prt	4:compound:prt	_
+5	of	off	ADP	RP	Typo=Yes	4	compound:prt	4:compound:prt	_
 6	my	my	PRON	PRP$	Number=Sing|Person=1|Poss=Yes|PronType=Prs	7	nmod:poss	7:nmod:poss	_
 7	phone	phone	NOUN	NN	Number=Sing	4	obj	4:obj	_
 8	and	and	CCONJ	CC	_	12	cc	12:cc	_

--- a/not-to-release/sources/reviews/349020.xml.conllu
+++ b/not-to-release/sources/reviews/349020.xml.conllu
@@ -79,9 +79,9 @@
 12	of	of	ADP	IN	_	14	case	14:case	_
 13	little	little	ADJ	JJ	Degree=Pos	14	amod	14:amod	_
 14	things	thing	NOUN	NNS	Number=Plur	11	nmod	11:nmod	_
-15	while	while	ADP	IN	_	17	case	17:case	_
+15	while	while	SCONJ	IN	_	17	mark	17:mark	_
 16	test	test	NOUN	NN	Number=Sing	17	compound	17:compound	_
-17	drive	drive	NOUN	NN	Number=Sing	7	obl	7:obl	SpaceAfter=No
+17	drive	driving	VERB	VBG	VerbForm=Ger|Typo=Yes	7	advcl	7:advcl	SpaceAfter=No
 18	.	.	PUNCT	.	_	2	punct	2:punct	_
 
 # sent_id = reviews-349020-0006

--- a/not-to-release/sources/reviews/355325.xml.conllu
+++ b/not-to-release/sources/reviews/355325.xml.conllu
@@ -26,7 +26,7 @@
 16	me	I	PRON	PRP	Case=Acc|Number=Sing|Person=1|PronType=Prs	15	iobj	15:iobj	_
 17	birthday	birthday	NOUN	NN	Number=Sing	18	compound	18:compound	_
 18	flowers	flower	NOUN	NNS	Number=Plur	15	obj	15:obj	_
-19	though	though	ADP	IN	_	20	case	20:case	_
+19	though	through	ADP	IN	Typo=Yes	20	case	20:case	_
 20	here	here	ADV	RB	PronType=Dem	15	obl	15:obl	SpaceAfter=No
 21	.	.	PUNCT	.	_	2	punct	2:punct	_
 

--- a/not-to-release/sources/reviews/360937.xml.conllu
+++ b/not-to-release/sources/reviews/360937.xml.conllu
@@ -162,7 +162,7 @@
 3	negative	negative	NOUN	NN	Number=Sing	11	nsubj	11:nsubj	_
 4	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	5	nsubj	5:nsubj	_
 5	have	have	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	3	acl:relcl	3:acl:relcl	_
-6	abou	abou	ADP	IN	_	8	case	8:case	_
+6	abou	about	ADP	IN	Typo=Yes	8	case	8:case	_
 7	this	this	DET	DT	Number=Sing|PronType=Dem	8	det	8:det	_
 8	place	place	NOUN	NN	Number=Sing	3	nmod	3:nmod	_
 9	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	11	cop	11:cop	_

--- a/not-to-release/sources/reviews/398243.xml.conllu
+++ b/not-to-release/sources/reviews/398243.xml.conllu
@@ -246,7 +246,7 @@
 18	cynical	cynical	ADJ	JJ	Degree=Pos	2	conj	2:conj	_
 19	about	about	ADP	IN	_	23	case	23:case	_
 20	city	city	NOUN	NN	Number=Sing	23	compound	23:compound	_
-21	auto	auto	ADP	NN	Number=Sing	22	compound	22:compound	_
+21	auto	auto	NOUN	NN	Number=Sing	22	compound	22:compound	_
 22	repair	repair	NOUN	NN	Number=Sing	23	compound	23:compound	_
 23	shops	shop	NOUN	NNS	Number=Plur	18	obl	18:obl	_
 24	since	since	SCONJ	IN	_	26	mark	26:mark	_

--- a/not-to-release/sources/weblog/blogspot.com_alaindewitt_20040929103700_ENG_20040929_103700.xml.conllu
+++ b/not-to-release/sources/weblog/blogspot.com_alaindewitt_20040929103700_ENG_20040929_103700.xml.conllu
@@ -1471,7 +1471,7 @@
 21	explain	explain	VERB	VB	VerbForm=Inf	18	xcomp	18:xcomp	_
 22	to	to	ADP	IN	_	23	case	23:case	_
 23	America	America	PROPN	NNP	Number=Sing	21	obl	21:obl	_
-24	whether	whether	ADP	IN	_	21	ccomp	21:ccomp	_
+24	whether	whether	SCONJ	IN	_	21	ccomp	21:ccomp	_
 25	or	or	CCONJ	CC	_	24	fixed	24:fixed	_
 26	not	not	ADV	RB	_	24	fixed	24:fixed	SpaceAfter=No
 27	,	,	PUNCT	,	_	29	punct	29:punct	_
@@ -1481,7 +1481,7 @@
 31	truth	truth	NOUN	NN	Number=Sing	29	obj	29:obj	SpaceAfter=No
 32	,	,	PUNCT	,	_	31	punct	31:punct	_
 33	about	about	SCONJ	IN	_	36	mark	36:mark	_
-34	whether	whether	ADP	IN	_	36	mark	36:mark	_
+34	whether	whether	SCONJ	IN	_	36	mark	36:mark	_
 35	he	he	PRON	PRP	Case=Nom|Gender=Masc|Number=Sing|Person=3|PronType=Prs	36	nsubj	36:nsubj	_
 36	showed	show	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	31	acl	31:acl	_
 37	up	up	ADP	RP	_	36	compound:prt	36:compound:prt	_

--- a/not-to-release/sources/weblog/blogspot.com_dakbangla_20050311135387_ENG_20050311_135387.xml.conllu
+++ b/not-to-release/sources/weblog/blogspot.com_dakbangla_20050311135387_ENG_20050311_135387.xml.conllu
@@ -3439,7 +3439,7 @@
 8	children	child	NOUN	NNS	Number=Plur	2	obl	2:obl	_
 9	to	to	PART	TO	_	10	mark	10:mark	_
 10	visit	visit	VERB	VB	VerbForm=Inf	2	xcomp	2:xcomp	_
-11	and	and	DET	DT	_	12	det	12:det	_
+11	and	a	DET	DT	Typo=Yes	12	det	12:det	_
 12	uncle	uncle	NOUN	NN	Number=Sing	10	obj	10:obj	_
 13	and	and	CCONJ	CC	_	15	cc	15:cc	_
 14	a	a	DET	DT	Definite=Ind|PronType=Art	15	det	15:det	_

--- a/not-to-release/sources/weblog/blogspot.com_tacitusproject_20040712123425_ENG_20040712_123425.xml.conllu
+++ b/not-to-release/sources/weblog/blogspot.com_tacitusproject_20040712123425_ENG_20040712_123425.xml.conllu
@@ -246,7 +246,7 @@
 # sent_id = weblog-blogspot.com_tacitusproject_20040712123425_ENG_20040712_123425-0013
 # text = But if -- there's a painting on the wall in the Oval Office that shows a horseman charging up a steep cliff, and there are at least two other horsemen following.
 1	But	but	CCONJ	CC	_	2	cc	2:cc	_
-2	if	if	ADP	IN	_	5	reparandum	5:reparandum	_
+2	if	if	SCONJ	IN	_	5	reparandum	5:reparandum	_
 3	--	--	PUNCT	,	_	5	punct	5:punct	_
 4	there	there	PRON	EX	_	5	expl	5:expl	SpaceAfter=No
 5	's	be	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	_

--- a/not-to-release/sources/weblog/typepad.com_ripples_20050410122300_ENG_20050410_122300.xml.conllu
+++ b/not-to-release/sources/weblog/typepad.com_ripples_20050410122300_ENG_20050410_122300.xml.conllu
@@ -691,7 +691,7 @@
 63	will	will	AUX	MD	VerbForm=Fin	65	aux	65:aux	_
 64	be	be	AUX	VB	VerbForm=Inf	65	aux:pass	65:aux:pass	_
 65	heard	hear	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	50	ccomp	50:ccomp	_
-66	admidst	admidst	ADP	IN	_	69	case	69:case	_
+66	admidst	amidst	ADP	IN	Typo=Yes	69	case	69:case	_
 67	the	the	DET	DT	Definite=Def|PronType=Art	69	det	69:det	_
 68	higher	higher	ADJ	JJR	Degree=Cmp	69	amod	69:amod	_
 69	echelons	echelon	NOUN	NNS	Number=Plur	65	obl	65:obl	_


### PR DESCRIPTION
Low-frequency types of (alleged) **prepositions**, **determiners**, and **conjunctions** have been manually inspected and corrected for typos, putting the correct spelling in the lemma and specifying `Typo=Yes` (see UniversalDependencies/docs#513).

The ones which were not typos were generally abbreviations (#40).