### PR TITLE
coordinated prepositions: second should attach to first, not object

### DIFF
--- a/not-to-release/sources/answers/20111108050147AAOkFgL_ans.xml.conllu
+++ b/not-to-release/sources/answers/20111108050147AAOkFgL_ans.xml.conllu
@@ -74,7 +74,7 @@
 30	it	it	PRON	PRP	Case=Nom|Gender=Neut|Number=Sing|Person=3|PronType=Prs	29	obj	29:obj	_
 31	before	before	ADP	IN	_	35	case	35:case	_
 32	or	or	CCONJ	CC	_	33	cc	33:cc	_
-33	after	after	ADP	IN	_	35	conj	35:conj	_
+33	after	after	ADP	IN	_	31	conj	31:conj	_
 34	medical	medical	ADJ	JJ	Degree=Pos	35	amod	35:amod	_
 35	school	school	NOUN	NN	Number=Sing	29	obl	29:obl	SpaceAfter=No
 36	?	?	PUNCT	.	_	25	punct	25:punct	_

--- a/not-to-release/sources/answers/20111108110329AAxl1pb_ans.xml.conllu
+++ b/not-to-release/sources/answers/20111108110329AAxl1pb_ans.xml.conllu
@@ -124,7 +124,7 @@
 47	other	other	ADJ	JJ	Degree=Pos	45	obj	45:obj	_
 48	up	up	ADP	IN	_	52	case	52:case	_
 49	and	and	CCONJ	CC	_	50	cc	50:cc	_
-50	down	down	ADP	IN	_	52	conj	52:conj	_
+50	down	down	ADP	IN	_	48	conj	48:conj	_
 51	the	the	DET	DT	Definite=Def|PronType=Art	52	det	52:det	_
 52	hall	hall	NOUN	NN	Number=Sing	45	obl	45:obl	SpaceAfter=No
 53	,	,	PUNCT	,	_	54	punct	54:punct	_

--- a/not-to-release/sources/email/enronsent02_01.xml.conllu
+++ b/not-to-release/sources/email/enronsent02_01.xml.conllu
@@ -289,7 +289,7 @@
 16	(	(	PUNCT	-LRB-	_	11	punct	11:punct	_
 17	above	above	ADP	IN	_	21	case	21:case	_
 18	and	and	CCONJ	CC	_	19	cc	19:cc	_
-19	beyond	beyond	ADP	IN	_	21	conj	21:conj	_
+19	beyond	beyond	ADP	IN	_	17	conj	17:conj	_
 20	existing	exist	VERB	VBG	VerbForm=Ger	21	amod	21:amod	_
 21	conversations	conversation	NOUN	NNS	Number=Plur	11	obl	11:obl	_
 22	with	with	ADP	IN	_	23	case	23:case	_

--- a/not-to-release/sources/email/enronsent03_01.xml.conllu
+++ b/not-to-release/sources/email/enronsent03_01.xml.conllu
@@ -375,7 +375,7 @@
 21	--	--	PUNCT	,	_	18	punct	18:punct	_
 22	with	with	ADP	IN	_	25	case	25:case	_
 23	and	and	CCONJ	CC	_	24	cc	24:cc	_
-24	without	without	ADP	IN	_	25	conj	25:conj	_
+24	without	without	ADP	IN	_	22	conj	22:conj	_
 25	non-compete	non-compete	NOUN	NN	Number=Sing	18	obl	18:obl	SpaceAfter=No
 26	)	)	PUNCT	-RRB-	_	18	punct	18:punct	SpaceAfter=No
 27	.	.	PUNCT	.	_	2	punct	2:punct	_

--- a/not-to-release/sources/email/enronsent10_01.xml.conllu
+++ b/not-to-release/sources/email/enronsent10_01.xml.conllu
@@ -987,7 +987,7 @@
 12	comments	comment	NOUN	NNS	Number=Plur	10	obj	10:obj	_
 13	on	on	ADP	IN	_	17	case	17:case	_
 14	or	or	CCONJ	CC	_	15	cc	15:cc	_
-15	before	before	ADP	IN	_	17	conj	17:conj	_
+15	before	before	ADP	IN	_	13	conj	13:conj	_
 16	Tuesday	Tuesday	PROPN	NNP	Number=Sing	17	compound	17:compound	_
 17	afternoon	afternoon	NOUN	NN	Number=Sing	7	obl	7:obl	_
 18	(	(	PUNCT	-LRB-	_	25	punct	25:punct	SpaceAfter=No

--- a/not-to-release/sources/email/enronsent35_01.xml.conllu
+++ b/not-to-release/sources/email/enronsent35_01.xml.conllu
@@ -1454,7 +1454,7 @@
 4	burgers	burger	NOUN	NNS	Number=Plur	3	obj	3:obj	_
 5	up	up	ADP	IN	_	10	case	10:case	_
 6	and	and	CCONJ	CC	_	7	cc	7:cc	_
-7	down	down	ADP	IN	_	10	conj	10:conj	_
+7	down	down	ADP	IN	_	5	conj	5:conj	_
 8	the	the	DET	DT	Definite=Def|PronType=Art	10	det	10:det	_
 9	east	east	ADJ	JJ	Degree=Pos	10	amod	10:amod	_
 10	coast	coast	NOUN	NN	Number=Sing	3	obl	3:obl	SpaceAfter=No

--- a/not-to-release/sources/newsgroup/groups.google.com_DungeonsDragonsChillicotheOH45601_022e6f4a0cd6fb61_ENG_20050829_233300.xml.conllu
+++ b/not-to-release/sources/newsgroup/groups.google.com_DungeonsDragonsChillicotheOH45601_022e6f4a0cd6fb61_ENG_20050829_233300.xml.conllu
@@ -19,7 +19,7 @@
 16	live	live	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	8	conj	8:conj	_
 17	in	in	ADP	IN	_	24	case	24:case	_
 18	or	or	CCONJ	CC	_	19	cc	19:cc	_
-19	around	around	ADP	IN	_	24	conj	24:conj	_
+19	around	around	ADP	IN	_	17	conj	17:conj	_
 20	the	the	DET	DT	Definite=Def|PronType=Art	24	det	24:det	_
 21	Chillicothe	Chillicothe	PROPN	NNP	Number=Sing	23	compound	23:compound	SpaceAfter=No
 22	,	,	PUNCT	,	_	23	punct	23:punct	_

--- a/not-to-release/sources/newsgroup/groups.google.com_Meditation20051_1027f5a3651d547c_ENG_20050316_085700.xml.conllu
+++ b/not-to-release/sources/newsgroup/groups.google.com_Meditation20051_1027f5a3651d547c_ENG_20050316_085700.xml.conllu
@@ -34,7 +34,7 @@
 10	excellent	excellent	ADJ	JJ	Degree=Pos	6	acl:relcl	6:acl:relcl	_
 11	before	before	ADP	IN	_	15	case	15:case	_
 12	and	and	CCONJ	CC	_	13	cc	13:cc	_
-13	after	after	ADP	IN	_	15	conj	15:conj	_
+13	after	after	ADP	IN	_	11	conj	11:conj	_
 14	yoga	yoga	NOUN	NN	Number=Sing	15	compound	15:compound	_
 15	postures	posture	NOUN	NNS	Number=Plur	10	obl	10:obl	SpaceAfter=No
 16	.	.	PUNCT	.	_	3	punct	3:punct	_

--- a/not-to-release/sources/newsgroup/groups.google.com_alt.animals.badgers_172dcd8baf26948f_ENG_20040823_121900.xml.conllu
+++ b/not-to-release/sources/newsgroup/groups.google.com_alt.animals.badgers_172dcd8baf26948f_ENG_20040823_121900.xml.conllu
@@ -20,7 +20,7 @@
 3	,	,	PUNCT	,	_	11	punct	11:punct	_
 4	in	in	ADP	IN	_	7	case	7:case	_
 5	and	and	CCONJ	CC	_	6	cc	6:cc	_
-6	of	of	ADP	IN	_	7	conj	7:conj	_
+6	of	of	ADP	IN	_	4	conj	4:conj	_
 7	itself	itself	PRON	PRP	Case=Acc|Gender=Neut|Number=Sing|Person=3|PronType=Prs|Reflex=Yes	11	obl	11:obl	SpaceAfter=No
 8	,	,	PUNCT	,	_	11	punct	11:punct	_
 9	a	a	DET	DT	Definite=Ind|PronType=Art	11	det	11:det	_

--- a/not-to-release/sources/newsgroup/groups.google.com_alt.animals.bears_07e0e03c803ffdbd_ENG_20040217_113500.xml.conllu
+++ b/not-to-release/sources/newsgroup/groups.google.com_alt.animals.bears_07e0e03c803ffdbd_ENG_20040217_113500.xml.conllu
@@ -190,7 +190,7 @@
 2	orders	order	NOUN	NNS	Number=Plur	0	root	0:root	_
 3	at	at	ADP	IN	_	6	case	6:case	_
 4	or	or	CCONJ	CC	_	5	cc	5:cc	_
-5	over	over	ADP	IN	_	6	conj	6:conj	_
+5	over	over	ADP	IN	_	3	conj	3:conj	_
 6	$	$	SYM	$	_	2	nmod	2:nmod	SpaceAfter=No
 7	500.00	500.00	NUM	CD	NumType=Card	6	nummod	6:nummod	_
 8	an	a	DET	DT	Definite=Ind|PronType=Art	11	det	11:det	_

--- a/not-to-release/sources/reviews/034320.xml.conllu
+++ b/not-to-release/sources/reviews/034320.xml.conllu
@@ -38,7 +38,7 @@
 15	art	art	NOUN	NN	Number=Sing	14	obj	14:obj	_
 16	to	to	ADP	IN	_	20	case	20:case	_
 17	/	/	PUNCT	HYPH	_	18	cc	18:cc	_
-18	with	with	ADP	IN	_	20	conj	20:conj	_
+18	with	with	ADP	IN	_	16	conj	16:conj	_
 19	commercial	commercial	ADJ	JJ	Degree=Pos	20	amod	20:amod	_
 20	purpose	purpose	NOUN	NN	Number=Sing	14	obl	14:obl	SpaceAfter=No
 21	.	.	PUNCT	.	_	2	punct	2:punct	_

--- a/not-to-release/sources/reviews/130647.xml.conllu
+++ b/not-to-release/sources/reviews/130647.xml.conllu
@@ -22,7 +22,7 @@
 3	sped	speed	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
 4	up	up	ADP	IN	_	8	case	8:case	_
 5	and	and	CCONJ	CC	_	6	cc	6:cc	_
-6	down	down	ADP	IN	_	8	conj	8:conj	_
+6	down	down	ADP	IN	_	4	conj	4:conj	_
 7	the	the	DET	DT	Definite=Def|PronType=Art	8	det	8:det	_
 8	street	street	NOUN	NN	Number=Sing	3	obl	3:obl	_
 9	with	with	ADP	IN	_	11	case	11:case	_

--- a/not-to-release/sources/reviews/315763.xml.conllu
+++ b/not-to-release/sources/reviews/315763.xml.conllu
@@ -157,7 +157,7 @@
 7	work	work	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	4	advcl	4:advcl	_
 8	in	in	ADP	IN	_	12	case	12:case	_
 9	and	and	CCONJ	CC	_	10	cc	10:cc	_
-10	around	around	ADV	RB	_	12	conj	12:conj	_
+10	around	around	ADP	IN	_	8	conj	8:conj	_
 11	downtown	downtown	ADV	RB	_	12	advmod	12:advmod	_
 12	San	San	PROPN	NNP	Number=Sing	7	obl	7:obl	_
 13	Jose	Jose	PROPN	NNP	Number=Sing	12	flat	12:flat	SpaceAfter=No

--- a/not-to-release/sources/reviews/396874.xml.conllu
+++ b/not-to-release/sources/reviews/396874.xml.conllu
@@ -80,7 +80,7 @@
 7	went	go	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
 8	over	over	ADP	IN	_	12	case	12:case	_
 9	and	and	CCONJ	CC	_	10	cc	10:cc	_
-10	above	above	ADP	IN	_	12	conj	12:conj	_
+10	above	above	ADP	IN	_	8	conj	8:conj	_
 11	the	the	DET	DT	Definite=Def|PronType=Art	12	det	12:det	_
 12	call	call	NOUN	NN	Number=Sing	7	obl	7:obl	_
 13	of	of	ADP	IN	_	14	case	14:case	_


### PR DESCRIPTION
Partially addresses #49