### PR TITLE
Identify more typos with the help of Gemini

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 Universal Dependencies - English Dependency Treebank
-Universal Dependencies English Web Treebank v2.17 -- 2025-11-15
+Universal Dependencies English Web Treebank v2.18 -- 2026-05-15
 https://github.com/UniversalDependencies/UD_English-EWT
 
 
@@ -151,6 +151,12 @@ documents many yet-to-be-resolved analysis challenges. Significant among these:
  - Many free relatives are incorrectly analyzed as interrogative.
 
 # Changelog
+
+**2026-05-15 v2.18**
+
+Highlights:
+
+  - Mark about 200 tokens as typos.
 
 **2025-11-15 v2.17**
 

--- a/en_ewt-ud-dev.conllu
+++ b/en_ewt-ud-dev.conllu
@@ -197,7 +197,7 @@
 12	a	a	DET	DT	Definite=Ind|PronType=Art	13	det	13:det	_
 13	wave	wave	NOUN	NN	Number=Sing	11	nsubj	11:nsubj	CxnElt=11:Existential-CopPred-ThereExpl.Pivot
 14	of	of	ADP	IN	_	17	case	17:case	_
-15	succesfull	succesfull	ADJ	JJ	Degree=Pos	17	amod	17:amod	_
+15	succesfull	successful	ADJ	JJ	Degree=Pos|Typo=Yes	17	amod	17:amod	CorrectForm=successful
 16	arab	Arab	ADJ	JJ	Degree=Pos	17	amod	17:amod	_
 17	attacks	attack	NOUN	NNS	Number=Plur	13	nmod	13:nmod:of	SpaceAfter=No
 18	.	.	PUNCT	.	_	3	punct	3:punct	_
@@ -286,7 +286,7 @@
 14	briefly	briefly	ADV	RB	_	15	advmod	15:advmod	_
 15	arrested	arrest	VERB	VBD	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	7	advcl	7:advcl:when	_
 16	a	a	DET	DT	Definite=Ind|PronType=Art	19	det	19:det	_
-17	yound	yound	ADJ	JJ	Degree=Pos	19	amod	19:amod	_
+17	yound	young	ADJ	JJ	Degree=Pos|Typo=Yes	19	amod	19:amod	CorrectForm=young
 18	newlywed	newlywed	ADJ	JJ	Degree=Pos	19	amod	19:amod	_
 19	bride	bride	NOUN	NN	Number=Sing	15	obj	15:obj	SpaceAfter=No
 20	.	.	PUNCT	.	_	7	punct	7:punct	_
@@ -1974,7 +1974,7 @@
 24	if	if	SCONJ	IN	_	30	mark	30:mark	_
 25	the	the	DET	DT	Definite=Def|PronType=Art	27	det	27:det	_
 26	Fallujah	Fallujah	PROPN	NNP	Number=Sing	27	compound	27:compound	_
-27	compaign	compaign	NOUN	NN	Number=Sing	30	nsubj:pass	30:nsubj:pass	_
+27	compaign	campaign	NOUN	NN	Number=Sing|Typo=Yes	30	nsubj:pass	30:nsubj:pass	CorrectForm=campaign
 28	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	30	aux:pass	30:aux:pass	_
 29	not	not	PART	RB	Polarity=Neg	30	advmod	30:advmod	_
 30	stopped	stop	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	22	advcl	22:advcl:if	CxnElt=22:Conditional-UnspecifiedEpistemic-NoInversion.Protasis|SpaceAfter=No
@@ -3216,7 +3216,7 @@
 7	other	other	ADJ	JJ	Degree=Pos	8	amod	8:amod	_
 8	writers	writer	NOUN	NNS	Number=Plur	6	obj	6:obj	_
 9	at	at	ADP	IN	_	10	case	10:case	_
-10	legnth	legnth	NOUN	NN	Number=Sing	6	obl	6:obl:at	_
+10	legnth	length	NOUN	NN	Number=Sing|Typo=Yes	6	obl	6:obl:at	CorrectForm=length
 11	in	in	ADP	IN	_	13	case	13:case	_
 12	this	this	DET	DT	Number=Sing|PronType=Dem	13	det	13:det	_
 13	space	space	NOUN	NN	Number=Sing	6	obl	6:obl:in	SpaceAfter=No
@@ -4222,7 +4222,7 @@
 6-7	Ben's	_	_	_	_	_	_	_	_
 6	Ben	Ben	PROPN	NNP	Number=Sing	8	nmod:poss	8:nmod:poss	_
 7	's	's	PART	POS	_	6	case	6:case	_
-8	annoucement	annoucement	NOUN	NN	Number=Sing	4	nmod	4:nmod:of	_
+8	annoucement	announcement	NOUN	NN	Number=Sing|Typo=Yes	4	nmod	4:nmod:of	CorrectForm=announcement
 9	yesterday	yesterday	NOUN	NN	Number=Sing	8	nmod:unmarked	8:nmod:unmarked	SpaceAfter=No|TemporalNPAdjunct=Yes
 10	,	,	PUNCT	,	_	4	punct	4:punct	_
 11	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	12	nsubj	12:nsubj	_
@@ -5927,7 +5927,7 @@
 2	am	be	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	4	aux	4:aux	_
 3	not	not	PART	RB	Polarity=Neg	4	advmod	4:advmod	_
 4	looking	look	VERB	VBG	Tense=Pres|VerbForm=Part	0	root	0:root	_
-5	foward	foward	ADV	RB	_	4	advmod	4:advmod	_
+5	foward	forward	ADV	RB	Typo=Yes	4	advmod	4:advmod	CorrectForm=forward
 6	to	to	ADP	IN	_	7	case	7:case	_
 7	that	that	PRON	DT	Number=Sing|PronType=Dem	4	obl	4:obl:to	_
 8	but	but	CCONJ	CC	_	11	cc	11:cc	_
@@ -6593,9 +6593,9 @@
 1	i	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	2	nsubj	2:nsubj	_
 2	satisfy	satisfy	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 3	your	your	PRON	PRP$	Case=Gen|Person=2|Poss=Yes|PronType=Prs	4	nmod:poss	4:nmod:poss	_
-4	appetitie	appetitie	NOUN	NN	Number=Sing	2	obj	2:obj	_
+4	appetitie	appetite	NOUN	NN	Number=Sing|Typo=Yes	2	obj	2:obj	CorrectForm=appetite
 5	for	for	ADP	IN	_	6	case	6:case	_
-6	lovin	lovin	NOUN	NN	Number=Sing	4	nmod	4:nmod:for	SpaceAfter=No
+6	lovin	lovin	NOUN	NN	Abbr=Yes|Number=Sing	4	nmod	4:nmod:for	SpaceAfter=No
 7	.	.	PUNCT	.	_	2	punct	2:punct	_
 
 # newdoc id = email-enronsent20_02
@@ -9917,7 +9917,7 @@
 3	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	7	cop	7:cop	_
 4	on	on	ADP	IN	_	7	case	7:case	_
 5	the	the	DET	DT	Definite=Def|PronType=Art	7	det	7:det	_
-6	fisrt	fisrt	ADJ	JJ	Degree=Pos	7	amod	7:amod	_
+6	fisrt	first	ADJ	JJ	Degree=Pos|Typo=Yes	7	amod	7:amod	CorrectForm=first
 7	tab	tab	NOUN	NN	Number=Sing	0	root	0:root	_
 8	of	of	ADP	IN	_	10	case	10:case	_
 9	the	the	DET	DT	Definite=Def|PronType=Art	10	det	10:det	_
@@ -10403,16 +10403,17 @@
 10	to	to	PART	TO	_	11	mark	11:mark	_
 11	discuss	discuss	VERB	VB	VerbForm=Inf	6	advcl	6:advcl:to	_
 12	any	any	DET	DT	PronType=Ind	13	det	13:det	_
-13	questionsand	questionsand	NOUN	NNS	Number=Plur	11	obj	11:obj|18:obj	_
-14	or	or	CCONJ	CC	_	15	cc	15:cc	_
-15	issues	issue	NOUN	NNS	Number=Plur	13	conj	11:obj|13:conj:or	_
-16	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	18	nsubj	18:nsubj	_
-17	may	may	AUX	MD	VerbForm=Fin	18	aux	18:aux	_
-18	have	have	VERB	VB	VerbForm=Inf	13	acl:relcl	13:acl:relcl	Cxn=rc-red-obj
-19	regarding	regard	VERB	VBG	Tense=Pres|VerbForm=Part	21	case	21:case	_
-20	this	this	DET	DT	Number=Sing|PronType=Dem	21	det	21:det	_
-21	matter	matter	NOUN	NN	Number=Sing	13	nmod	13:nmod:regarding	SpaceAfter=No
-22	.	.	PUNCT	.	_	6	punct	6:punct	_
+13	questions	question	NOUN	NNS	Number=Plur	11	obj	11:obj|18:obj	CorrectSpaceAfter=Yes|SpaceAfter=No
+14	and	and	CCONJ	CC	_	16	cc	16:cc	_
+15	or	or	CCONJ	CC	_	14	conj	14:conj	_
+16	issues	issue	NOUN	NNS	Number=Plur	13	conj	11:obj|13:conj:and_or	_
+17	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	19	nsubj	19:nsubj	_
+18	may	may	AUX	MD	VerbForm=Fin	19	aux	19:aux	_
+19	have	have	VERB	VB	VerbForm=Inf	13	acl:relcl	13:acl:relcl	Cxn=rc-red-obj
+20	regarding	regard	VERB	VBG	Tense=Pres|VerbForm=Part	22	case	22:case	_
+21	this	this	DET	DT	Number=Sing|PronType=Dem	22	det	22:det	_
+22	matter	matter	NOUN	NN	Number=Sing	13	nmod	13:nmod:regarding	SpaceAfter=No
+23	.	.	PUNCT	.	_	6	punct	6:punct	_
 
 # sent_id = email-enronsent29_01-0015
 # text = (See attached file: Constellation Power (GISB draft).doc)(See attached file: Sam3102.doc)
@@ -10556,7 +10557,7 @@
 
 # sent_id = email-enronsent29_01-0027
 # text = Thx
-1	Thx	thx	NOUN	NN	Number=Sing	0	root	0:root	_
+1	Thx	thanks	NOUN	NN	Abbr=Yes|Number=Sing	0	root	0:root	_
 
 # sent_id = email-enronsent29_01-0028
 # text = dp
@@ -11156,7 +11157,7 @@
 # sent_id = email-enronsent19_02-0006
 # text = My mane is Visit Phunnarungsi.
 1	My	my	PRON	PRP$	Case=Gen|Number=Sing|Person=1|Poss=Yes|PronType=Prs	2	nmod:poss	2:nmod:poss	_
-2	mane	mane	NOUN	NN	Number=Sing	5	nsubj	5:nsubj	_
+2	mane	name	NOUN	NN	Number=Sing|Typo=Yes	5	nsubj	5:nsubj	CorrectForm=name
 3	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	5	cop	5:cop	_
 4	Visit	Visit	PROPN	NNP	Number=Sing	5	compound	5:compound	_
 5	Phunnarungsi	Phunnarungsi	PROPN	NNP	Number=Sing	0	root	0:root	SpaceAfter=No
@@ -11370,7 +11371,7 @@
 5	if	if	SCONJ	IN	_	8	mark	8:mark	_
 6	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	8	nsubj	8:nsubj	_
 7	could	could	AUX	MD	VerbForm=Fin	8	aux	8:aux	_
-8	advice	advice	VERB	VB	VerbForm=Inf	4	advcl	4:advcl:if	CxnElt=4:Conditional-UnspecifiedEpistemic-NoInversion.Protasis
+8	advice	advise	VERB	VB	Typo=Yes|VerbForm=Inf	4	advcl	4:advcl:if	CorrectForm=advise|CxnElt=4:Conditional-UnspecifiedEpistemic-NoInversion.Protasis
 9	me	I	PRON	PRP	Case=Acc|Number=Sing|Person=1|PronType=Prs	8	obj	8:obj	_
 10	on	on	ADP	IN	_	12	case	12:case	_
 11	this	this	DET	DT	Number=Sing|PronType=Dem	12	det	12:det	_
@@ -13698,7 +13699,7 @@
 48	the	the	DET	DT	Definite=Def|PronType=Art	49	det	49:det	_
 49	links	link	NOUN	NNS	Number=Plur	47	obj	47:obj	_
 50	soon	soon	ADV	RB	Degree=Pos	47	advmod	47:advmod	_
-51	sry	sry	INTJ	UH	_	47	discourse	47:discourse	SpaceAfter=No
+51	sry	sorry	INTJ	UH	Abbr=Yes	47	discourse	47:discourse	SpaceAfter=No
 52	.	.	PUNCT	.	_	6	punct	6:punct	_
 
 # sent_id = newsgroup-groups.google.com_RagnarokOnlineII_acbece2a311cfb3c_ENG_20051119_076100-0003
@@ -18680,7 +18681,7 @@
 # text = like 2day
 1	like	like	INTJ	UH	_	3	discourse	3:discourse	_
 2	2	2	NUM	CD	NumForm=Digit|NumType=Card	3	nummod	3:nummod	SpaceAfter=No
-3	day	day	NOUN	NN	Number=Sing	0	root	0:root	_
+3	day	day	NOUN	NN	Number=Sing|Typo=Yes	0	root	0:root	CorrectForm=days|CorrectNumber=Plur
 
 # newdoc id = answers-20111108092417AAt9bST_ans
 # sent_id = answers-20111108092417AAt9bST_ans-0001
@@ -20505,11 +20506,11 @@
 
 # sent_id = answers-20111107173224AA22AwU_ans-0007
 # text = just in the water?
-1	just	just	ADV	RB	_	0	root	0:root	_
+1	just	just	ADV	RB	_	4	advmod	4:advmod	_
 2	in	in	ADP	IN	_	4	case	4:case	_
 3	the	the	DET	DT	Definite=Def|PronType=Art	4	det	4:det	_
-4	water	water	NOUN	NN	Number=Sing	1	obl	1:obl:in	SpaceAfter=No
-5	?	?	PUNCT	.	_	1	punct	1:punct	_
+4	water	water	NOUN	NN	Number=Sing	0	root	0:root	SpaceAfter=No
+5	?	?	PUNCT	.	_	4	punct	4:punct	_
 
 # sent_id = answers-20111107173224AA22AwU_ans-0008
 # newpar id = answers-20111107173224AA22AwU_ans-p0005
@@ -23869,7 +23870,7 @@
 11	the	the	DET	DT	Definite=Def|PronType=Art	12	det	12:det	_
 12	eggs	egg	NOUN	NNS	Number=Plur	16	nsubj	16:nsubj	_
 13	will	will	AUX	MD	VerbForm=Fin	16	aux	16:aux	_
-14	aways	aways	ADV	RB	_	16	advmod	16:advmod	_
+14	aways	always	ADV	RB	Typo=Yes	16	advmod	16:advmod	CorrectForm=always
 15	be	be	AUX	VB	VerbForm=Inf	16	cop	16:cop	_
 16	infertile	infertile	ADJ	JJ	Degree=Pos	0	root	0:root	Cxn=Conditional-UnspecifiedEpistemic-NoInversion|CxnElt=16:Conditional-UnspecifiedEpistemic-NoInversion.Apodosis|SpaceAfter=No
 17	.	.	PUNCT	.	_	16	punct	16:punct	_
@@ -25541,7 +25542,7 @@
 # newpar id = reviews-076440-p0001
 # text = really amazing the new and exciting plays done at this theatre !
 1	really	really	ADV	RB	_	2	advmod	2:advmod	_
-2	amazing	amazing	ADJ	JJ	Degree=Pos	7	nsubj	7:nsubj	_
+2	amazing	amazing	ADJ	JJ	Degree=Pos	7	dislocated	7:dislocated	_
 3	the	the	DET	DT	Definite=Def|PronType=Art	7	det	7:det	_
 4	new	new	ADJ	JJ	Degree=Pos	7	amod	7:amod	_
 5	and	and	CCONJ	CC	_	6	cc	6:cc	_

--- a/en_ewt-ud-dev.conllu
+++ b/en_ewt-ud-dev.conllu
@@ -23870,7 +23870,7 @@
 11	the	the	DET	DT	Definite=Def|PronType=Art	12	det	12:det	_
 12	eggs	egg	NOUN	NNS	Number=Plur	16	nsubj	16:nsubj	_
 13	will	will	AUX	MD	VerbForm=Fin	16	aux	16:aux	_
-14	aways	always	ADV	RB	Typo=Yes	16	advmod	16:advmod	CorrectForm=always
+14	aways	always	ADV	RB	PronType=Tot|Typo=Yes	16	advmod	16:advmod	CorrectForm=always
 15	be	be	AUX	VB	VerbForm=Inf	16	cop	16:cop	_
 16	infertile	infertile	ADJ	JJ	Degree=Pos	0	root	0:root	Cxn=Conditional-UnspecifiedEpistemic-NoInversion|CxnElt=16:Conditional-UnspecifiedEpistemic-NoInversion.Apodosis|SpaceAfter=No
 17	.	.	PUNCT	.	_	16	punct	16:punct	_

--- a/en_ewt-ud-test.conllu
+++ b/en_ewt-ud-test.conllu
@@ -248,7 +248,7 @@
 8	few	few	ADJ	JJ	Degree=Pos	5	nmod	5:nmod:on	_
 9	of	of	ADP	IN	_	11	case	11:case	_
 10	the	the	DET	DT	Definite=Def|PronType=Art	11	det	11:det	_
-11	pic's	pic	NOUN	NNS	Number=Plur	8	nmod	8:nmod:of	SpaceAfter=No
+11	pic's	pic	NOUN	NNS	Abbr=Yes|Number=Plur|Typo=Yes	8	nmod	8:nmod:of	CorrectForm=pics|SpaceAfter=No
 12	.	.	PUNCT	.	_	2	punct	2:punct	_
 
 # sent_id = weblog-blogspot.com_floppingaces_20041126180010_ENG_20041126_180010-0005
@@ -1044,7 +1044,7 @@
 11	Rumsfeld	Rumsfeld	PROPN	NNP	Number=Sing	9	nmod	9:nmod:versus	_
 12	divided	divide	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	4	advcl	4:advcl	_
 13	along	along	ADP	IN	_	15	case	15:case	_
-14	idelogical	idelogical	ADJ	JJ	Degree=Pos	15	amod	15:amod	_
+14	idelogical	ideological	ADJ	JJ	Degree=Pos|Typo=Yes	15	amod	15:amod	CorrectForm=ideological
 15	lines	line	NOUN	NNS	Number=Plur	12	obl	12:obl:along	_
 16	with	with	SCONJ	IN	_	19	mark	19:mark	_
 17	John	John	PROPN	NNP	Number=Sing	19	nsubj	19:nsubj	_
@@ -2760,7 +2760,7 @@
 3	the	the	DET	DT	Definite=Def|PronType=Art	4	det	4:det	_
 4	Occupation	occupation	NOUN	NN	Number=Sing	6	nsubj	6:nsubj	_
 5	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	6	cop	6:cop	_
-6	emphemeral	emphemeral	ADJ	JJ	Degree=Pos	1	ccomp	1:ccomp	SpaceAfter=No
+6	emphemeral	ephemeral	ADJ	JJ	Degree=Pos|Typo=Yes	1	ccomp	1:ccomp	CorrectForm=ephemeral|SpaceAfter=No
 7	.	.	PUNCT	.	_	1	punct	1:punct	SpaceAfter=No
 8	"	"	PUNCT	''	_	1	punct	1:punct	_
 
@@ -2873,7 +2873,7 @@
 5	ploy	ploy	NOUN	NN	Number=Sing	2	xcomp	2:xcomp	SpaceAfter=No
 6	"	"	PUNCT	''	_	5	punct	5:punct	_
 7	the	the	DET	DT	Definite=Def|PronType=Art	8	det	8:det	_
-8	assertaion	assertaion	NOUN	NN	Number=Sing	2	obj	2:obj|5:nsubj:xsubj	_
+8	assertaion	assertion	NOUN	NN	Number=Sing|Typo=Yes	2	obj	2:obj|5:nsubj:xsubj	CorrectForm=assertion
 9	that	that	SCONJ	IN	_	16	mark	16:mark	_
 10	the	the	DET	DT	Definite=Def|PronType=Art	11	det	11:det	_
 11	attack	attack	NOUN	NN	Number=Sing	16	nsubj	16:nsubj	_
@@ -5825,7 +5825,7 @@
 10	the	the	DET	DT	Definite=Def|PronType=Art	11	det	11:det	_
 11	layoffs	layoff	NOUN	NNS	Number=Plur	8	nmod	8:nmod:of	_
 12	affect	affect	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	6	advcl	6:advcl:because	_
-13	satelite	satelite	NOUN	NN	Number=Sing	14	compound	14:compound	_
+13	satelite	sattelite	NOUN	NN	Number=Sing|Typo=Yes	14	compound	14:compound	CorrectForm=sattelite
 14	offices	office	NOUN	NNS	Number=Plur	12	obj	12:obj	SpaceAfter=No
 15	.	.	PUNCT	.	_	6	punct	6:punct	_
 
@@ -7049,7 +7049,7 @@
 9	suitable	suitable	ADJ	JJ	Degree=Pos	13	amod	13:amod	_
 10	20	20	NUM	CD	NumForm=Digit|NumType=Card	11	nummod	11:nummod	_
 11	year	year	NOUN	NN	Number=Sing	12	compound	12:compound	_
-12	volalatility	volalatility	NOUN	NN	Number=Sing	13	compound	13:compound	_
+12	volalatility	volatility	NOUN	NN	Number=Sing|Typo=Yes	13	compound	13:compound	CorrectForm=volatility
 13	number	number	NOUN	NN	Number=Sing	7	obj	7:obj	_
 14	for	for	ADP	IN	_	17	case	17:case	_
 15	USD	usd	NOUN	NN	Number=Sing	17	compound	17:compound	SpaceAfter=No
@@ -7610,7 +7610,7 @@
 8	in	in	ADP	IN	_	11	case	11:case	_
 9	his	his	PRON	PRP$	Case=Gen|Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	11	nmod:poss	11:nmod:poss	_
 10	separate	separate	ADJ	JJ	Degree=Pos	11	amod	11:amod	_
-11	e'mail	e'mail	NOUN	NN	Number=Sing	7	obl	7:obl:in	SpaceAfter=No
+11	e'mail	e-mail	NOUN	NN	Number=Sing|Typo=Yes	7	obl	7:obl:in	CorrectForm=e-mail|SpaceAfter=No
 12	.	.	PUNCT	.	_	2	punct	2:punct	_
 
 # sent_id = email-enronsent32_02-0027
@@ -7784,7 +7784,7 @@
 15	)	)	PUNCT	-RRB-	_	14	punct	14:punct	SpaceAfter=No
 16	]	]	PUNCT	-RRB-	_	7	punct	7:punct	_
 17	who	who	PRON	WP	PronType=Rel	18	nsubj	4:ref	_
-18	conrfirmed	conrfirm	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	4	acl:relcl	4:acl:relcl	Cxn=rc-wh-nsubj
+18	conrfirmed	confirm	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|Typo=Yes|VerbForm=Fin	4	acl:relcl	4:acl:relcl	CorrectForm=confirmed|Cxn=rc-wh-nsubj
 19	to	to	ADP	IN	_	20	case	20:case	_
 20	me	I	PRON	PRP	Case=Acc|Number=Sing|Person=1|PronType=Prs	18	obl	18:obl:to	_
 21	that	that	SCONJ	IN	_	24	mark	24:mark	_
@@ -15747,7 +15747,7 @@
 # sent_id = newsgroup-groups.google.com_alt.animals.bears_07e0e03c803ffdbd_ENG_20040217_113500-0014
 # text = We accecpt: Visa, MasterCard, Amex, Dinners Club/Carte Blanche, & Personal Checks/Money Orders.
 1	We	we	PRON	PRP	Case=Nom|Number=Plur|Person=1|PronType=Prs	2	nsubj	2:nsubj	_
-2	accecpt	accecpt	VERB	VBP	Mood=Ind|Number=Plur|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	SpaceAfter=No
+2	accecpt	accept	VERB	VBP	Mood=Ind|Number=Plur|Person=1|Tense=Pres|Typo=Yes|VerbForm=Fin	0	root	0:root	CorrectForm=accept|SpaceAfter=No
 3	:	:	PUNCT	:	_	4	punct	4:punct	_
 4	Visa	Visa	PROPN	NNP	Number=Sing	2	obj	2:obj	SpaceAfter=No
 5	,	,	PUNCT	,	_	6	punct	6:punct	_
@@ -15859,7 +15859,7 @@
 9	Avant	avant	NOUN	NN	Number=Sing	11	compound	11:compound	SpaceAfter=No
 10	-	-	PUNCT	HYPH	_	9	punct	9:punct	SpaceAfter=No
 11	Garde	garde	NOUN	NN	Number=Sing	12	compound	12:compound	_
-12	artist	artist	NOUN	NN	Number=Sing	5	nmod	5:nmod:of	_
+12	artist	artist	NOUN	NN	Number=Sing|Typo=Yes	5	nmod	5:nmod:of	CorrectForm=artists|CorrectNumber=Plur
 13	of	of	ADP	IN	_	15	case	15:case	_
 14	modern	modern	ADJ	JJ	Degree=Pos	15	amod	15:amod	_
 15	calligraphy	calligraphy	NOUN	NN	Number=Sing	12	nmod	12:nmod:of	SpaceAfter=No
@@ -16238,7 +16238,7 @@
 7	put	put	VERB	VB	VerbForm=Inf	0	root	0:root	_
 8	it	it	PRON	PRP	Case=Acc|Gender=Neut|Number=Sing|Person=3|PronType=Prs	7	obj	7:obj	_
 9	on	on	ADP	IN	_	10	case	10:case	_
-10	coarse	coarse	NOUN	NN	Number=Sing	7	obl	7:obl:on	_
+10	coarse	course	NOUN	NN	Number=Sing|Typo=Yes	7	obl	7:obl:on	CorrectForm=course
 11	for	for	ADP	IN	_	13	case	13:case	_
 12	global	global	ADJ	JJ	Degree=Pos	13	amod	13:amod	_
 13	domination	domination	NOUN	NN	Number=Sing	10	nmod	10:nmod:for	_

--- a/en_ewt-ud-test.conllu
+++ b/en_ewt-ud-test.conllu
@@ -19051,7 +19051,7 @@
 
 # sent_id = answers-20111108073410AAlpgTl_ans-0002
 # text = thx for your ans.?
-1	thx	thx	NOUN	NN	Number=Sing	0	root	0:root	_
+1	thx	thanks	NOUN	NN	Abbr=Yes|Number=Sing	0	root	0:root	_
 2	for	for	ADP	IN	_	4	case	4:case	_
 3	your	your	PRON	PRP$	Case=Gen|Person=2|Poss=Yes|PronType=Prs	4	nmod:poss	4:nmod:poss	_
 4	ans	ans	NOUN	NN	Number=Sing	1	nmod	1:nmod:for	SpaceAfter=No

--- a/en_ewt-ud-train.conllu
+++ b/en_ewt-ud-train.conllu
@@ -47370,7 +47370,7 @@
 3	did	do	AUX	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	5	aux	5:aux	_
 4	n't	not	PART	RB	Polarity=Neg	5	advmod	5:advmod	_
 5	spel	spell	VERB	VB	Typo=Yes|VerbForm=Inf	0	root	0:root	CorrectForm=sepll
-6	anyting	anything	NOUN	NN	Number=Sing|Typo=Yes	5	obj	5:obj	CorrectForm=anything
+6	anyting	anything	PRON	NN	Number=Sing|PronType=Ind|Typo=Yes	5	obj	5:obj	CorrectForm=anything
 7	incorrectly	incorrectly	ADV	RB	_	5	advmod	5:advmod	SpaceAfter=No
 8	.	.	PUNCT	.	_	5	punct	5:punct	_
 
@@ -141451,8 +141451,8 @@
 8	newest	new	ADJ	JJS	Degree=Sup	9	amod	9:amod	_
 9	version	version	NOUN	NN	Number=Sing	6	obj	6:obj	_
 10	of	of	ADP	IN	_	12	case	12:case	_
-11	Cyanogen	cyanogen	PROPN	NNP	Number=Sing	12	compound	12:compound	_
-12	Mod	mod	PROPN	NNP	Number=Sing	9	nmod	9:nmod:of	SpaceAfter=No
+11	Cyanogen	Cyanogen	PROPN	NNP	Number=Sing	12	compound	12:compound	_
+12	Mod	Mod	PROPN	NNP	Number=Sing	9	nmod	9:nmod:of	SpaceAfter=No
 13	.	.	PUNCT	.	_	6	punct	6:punct	_
 
 # sent_id = answers-20111108084119AAhsBk8_ans-0005

--- a/en_ewt-ud-train.conllu
+++ b/en_ewt-ud-train.conllu
@@ -2191,7 +2191,7 @@
 22	and	and	CCONJ	CC	_	23	cc	23:cc	_
 23	Elimination	Elimination	PROPN	NNP	Number=Sing	19	conj	16:nmod:on|19:conj:and	_
 24	of	of	ADP	IN	_	25	case	25:case	_
-25	Conseguences	Conseguence	PROPN	NNPS	Number=Plur	23	nmod	23:nmod:of	_
+25	Conseguences	Consequence	PROPN	NNPS	Number=Plur|Typo=Yes	23	nmod	23:nmod:of	CorrectForm=Consequences
 26	of	of	ADP	IN	_	28	case	28:case	_
 27	Natural	Natural	ADJ	NNP	Degree=Pos	28	amod	28:amod	_
 28	Disasters	Disaster	PROPN	NNPS	Number=Plur	25	nmod	25:nmod:of	_
@@ -6587,7 +6587,7 @@
 10	expert	expert	NOUN	NN	Number=Sing	4	appos	4:appos	_
 11	at	at	ADP	IN	_	15	case	15:case	_
 12	the	the	DET	DT	Definite=Def|PronType=Art	15	det	15:det	_
-13	Jawaharal	Jawaharal	PROPN	NNP	Number=Sing	15	compound	15:compound	_
+13	Jawaharal	Jawaharlal	PROPN	NNP	Number=Sing|Typo=Yes	15	compound	15:compound	CorrectForm=Jawaharlal
 14	Nehru	Nehru	PROPN	NNP	Number=Sing	13	flat	13:flat	_
 15	University	University	PROPN	NNP	Number=Sing	10	nmod	10:nmod:at	SpaceAfter=No
 16	,	,	PUNCT	,	_	4	punct	4:punct	_
@@ -11061,7 +11061,7 @@
 5	that	that	SCONJ	IN	_	10	mark	10:mark	_
 6	"	"	PUNCT	``	_	8	punct	8:punct	SpaceAfter=No
 7	His	his	PRON	PRP$	Case=Gen|Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	8	nmod:poss	8:nmod:poss	_
-8	Emminence	Emminence	PROPN	NNP	Number=Sing	10	nsubj	10:nsubj|13:nsubj:xsubj	SpaceAfter=No
+8	Emminence	Eminence	PROPN	NNP	Number=Sing|Typo=Yes	10	nsubj	10:nsubj|13:nsubj:xsubj	CorrectForm=Eminence|SpaceAfter=No
 9	"	"	PUNCT	''	_	8	punct	8:punct	_
 10	decided	decide	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	4	ccomp	4:ccomp	_
 11	to	to	PART	TO	_	13	mark	13:mark	_
@@ -11843,7 +11843,7 @@
 31	many	many	ADJ	JJ	Degree=Pos	33	nsubj	33:nsubj	_
 32	have	have	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	33	aux	33:aux	_
 33	formed	form	VERB	VBN	Tense=Past|VerbForm=Part	24	advcl	24:advcl:though	_
-34	seperate	seperate	ADJ	JJ	Degree=Pos	35	amod	35:amod	_
+34	seperate	separate	ADJ	JJ	Degree=Pos|Typo=Yes	35	amod	35:amod	CorrectForm=separate
 35	cells	cell	NOUN	NNS	Number=Plur	33	obj	33:obj	_
 36	(	(	PUNCT	-LRB-	_	40	punct	40:punct	SpaceAfter=No
 37	often	often	ADV	RB	_	40	advmod	40:advmod	_
@@ -13551,7 +13551,7 @@
 7	Lynn	Lynn	PROPN	NNP	Number=Sing	14	nsubj	14:nsubj	_
 8	Hughes	Hughes	PROPN	NNP	Number=Sing	7	flat	7:flat	_
 9	in	in	ADP	IN	_	10	case	10:case	_
-10	Huston	Huston	PROPN	NNP	Number=Sing	7	nmod	7:nmod:in	SpaceAfter=No
+10	Huston	Houston	PROPN	NNP	Number=Sing|Typo=Yes	7	nmod	7:nmod:in	CorrectForm=Houston|SpaceAfter=No
 11	,	,	PUNCT	,	_	12	punct	12:punct	_
 12	Texas	Texas	PROPN	NNP	Number=Sing	10	nmod:unmarked	10:nmod:unmarked	SpaceAfter=No|Superlocation=Yes
 13	,	,	PUNCT	,	_	7	punct	7:punct	_
@@ -13614,7 +13614,7 @@
 7	head	head	NOUN	NN	Number=Sing	5	obj	5:obj	_
 8	again	again	ADV	RB	_	5	advmod	5:advmod	_
 9	in	in	ADP	IN	_	10	case	10:case	_
-10	Louisianna	Louisianna	PROPN	NNP	Number=Sing	5	obl	5:obl:in	SpaceAfter=No
+10	Louisianna	Louisiana	PROPN	NNP	Number=Sing|Typo=Yes	5	obl	5:obl:in	CorrectForm=Louisiana|SpaceAfter=No
 11	..	..	PUNCT	.	_	1	punct	1:punct	_
 
 # sent_id = weblog-blogspot.com_rigorousintuition_20050518101500_ENG_20050518_101500-0054
@@ -24215,7 +24215,7 @@
 12	"	"	PUNCT	''	_	11	punct	11:punct	_
 13	when	when	ADV	WRB	PronType=Int	16	advmod	16:advmod	_
 14	they	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	16	nsubj	16:nsubj	_
-15	indescriminately	indescriminately	ADV	RB	_	16	advmod	16:advmod	_
+15	indescriminately	indiscriminately	ADV	RB	Typo=Yes	16	advmod	16:advmod	CorrectForm=indiscriminately
 16	murdered	murder	VERB	VBD	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	6	advcl	6:advcl:when	_
 17	their	their	PRON	PRP$	Case=Gen|Number=Plur|Person=3|Poss=Yes|PronType=Prs	18	nmod:poss	18:nmod:poss	_
 18	classmates	classmate	NOUN	NNS	Number=Plur	16	obj	16:obj	SpaceAfter=No
@@ -24664,7 +24664,7 @@
 5	:	:	PUNCT	:	_	24	punct	24:punct	_
 6	When	when	ADV	WRB	PronType=Int	11	advmod	11:advmod	_
 7	the	the	DET	DT	Definite=Def|PronType=Art	10	det	10:det	_
-8	appartently	appartently	ADV	RB	_	10	advmod	10:advmod	_
+8	appartently	apparently	ADV	RB	Typo=Yes	10	advmod	10:advmod	CorrectForm=apparently
 9	cognitively	cognitively	ADV	RB	_	10	advmod	10:advmod	_
 10	functional	functional	ADJ	JJ	Degree=Pos	11	nsubj	11:nsubj	_
 11	take	take	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	24	advcl	24:advcl:when	_
@@ -26228,11 +26228,11 @@
 # sent_id = weblog-blogspot.com_rigorousintuition_20060511134300_ENG_20060511_134300-0256
 # text = But succintly making point after succint point, the text of the letter stands on its own merit, regardless.
 1	But	but	CCONJ	CC	_	14	cc	14:cc	_
-2	succintly	succintly	ADV	RB	_	3	advmod	3:advmod	_
+2	succintly	succinctly	ADV	RB	Typo=Yes	3	advmod	3:advmod	CorrectForm=succinctly
 3	making	make	VERB	VBG	Tense=Pres|VerbForm=Part	14	advcl	14:advcl	_
 4	point	point	NOUN	NN	Number=Sing	3	obj	3:obj	_
 5	after	after	ADP	IN	_	7	case	7:case	_
-6	succint	succint	ADJ	JJ	Degree=Pos	7	amod	7:amod	_
+6	succint	succinct	ADJ	JJ	Degree=Pos|Typo=Yes	7	amod	7:amod	CorrectForm=succinct
 7	point	point	NOUN	NN	Number=Sing	4	nmod	4:nmod:after	SpaceAfter=No
 8	,	,	PUNCT	,	_	3	punct	3:punct	_
 9	the	the	DET	DT	Definite=Def|PronType=Art	10	det	10:det	_
@@ -26927,7 +26927,7 @@
 25	top	top	NOUN	NN	Number=Sing	22	nmod	22:nmod:at	_
 26	of	of	ADP	IN	_	30	case	30:case	_
 27	a	a	DET	DT	Definite=Ind|PronType=Art	30	det	30:det	_
-28	pyrimidal	pyrimidal	ADJ	JJ	Degree=Pos	30	amod	30:amod	_
+28	pyrimidal	pyramidal	ADJ	JJ	Degree=Pos|Typo=Yes	30	amod	30:amod	CorrectForm=pyramidal
 29	power	power	NOUN	NN	Number=Sing	30	compound	30:compound	_
 30	structure	structure	NOUN	NN	Number=Sing	25	nmod	25:nmod:of	SpaceAfter=No
 31	)	)	PUNCT	-RRB-	_	22	punct	22:punct	_
@@ -33753,7 +33753,7 @@
 12	's	's	PART	POS	_	11	case	11:case	_
 13	taking	taking	NOUN	NN	Number=Sing	10	obj	10:obj	_
 14	of	of	ADP	IN	_	15	case	15:case	_
-15	mecca	mecca	PROPN	NNP	Number=Sing	13	nmod	13:nmod:of	_
+15	mecca	Mecca	PROPN	NNP	Number=Sing	13	nmod	13:nmod:of	_
 16	by	by	ADP	IN	_	19	case	19:case	_
 17	a	a	DET	DT	Definite=Ind|PronType=Art	19	det	19:det	_
 18	small	small	ADJ	JJ	Degree=Pos	19	amod	19:amod	_
@@ -35266,7 +35266,7 @@
 12	's	's	PART	POS	_	11	case	11:case	_
 13	taking	taking	NOUN	NN	Number=Sing	10	obj	10:obj	_
 14	of	of	ADP	IN	_	15	case	15:case	_
-15	mecca	mecca	PROPN	NNP	Number=Sing	13	nmod	13:nmod:of	_
+15	mecca	Mecca	PROPN	NNP	Number=Sing	13	nmod	13:nmod:of	_
 16	by	by	ADP	IN	_	19	case	19:case	_
 17	a	a	DET	DT	Definite=Ind|PronType=Art	19	det	19:det	_
 18	small	small	ADJ	JJ	Degree=Pos	19	amod	19:amod	_
@@ -40553,7 +40553,7 @@
 
 # sent_id = email-enronsent19_01-0014
 # text = Columbia
-1	Columbia	Columbia	PROPN	NNP	Number=Sing	0	root	0:root	_
+1	Columbia	Colombia	PROPN	NNP	Number=Sing|Typo=Yes	0	root	0:root	CorrectForm=Colombia
 
 # sent_id = email-enronsent19_01-0015
 # text = Puerto Rico CPI only (I need historical inflation data, as well)
@@ -40929,7 +40929,7 @@
 5	-	-	PUNCT	,	_	9	punct	9:punct	_
 6	this	this	PRON	DT	Number=Sing|PronType=Dem	9	nsubj	9:nsubj	_
 7	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	9	cop	9:cop	_
-8	ling	ling	ADV	RB	_	9	advmod	9:advmod	_
+8	ling	long	ADV	RB	Typo=Yes	9	advmod	9:advmod	CorrectForm=long
 9	overdue	overdue	ADJ	JJ	Degree=Pos	1	parataxis	1:parataxis	_
 
 # sent_id = email-enronsent19_01-0041
@@ -41001,7 +41001,7 @@
 5	-	-	PUNCT	,	_	9	punct	9:punct	_
 6	this	this	PRON	DT	Number=Sing|PronType=Dem	9	nsubj	9:nsubj	_
 7	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	9	cop	9:cop	_
-8	ling	ling	ADV	RB	_	9	advmod	9:advmod	_
+8	ling	long	ADV	RB	Typo=Yes	9	advmod	9:advmod	CorrectForm=long
 9	overdue	overdue	ADJ	JJ	Degree=Pos	1	parataxis	1:parataxis	_
 
 # sent_id = email-enronsent19_01-0048
@@ -41715,7 +41715,7 @@
 20	to	to	PART	TO	_	21	mark	21:mark	_
 21	implement	implement	VERB	VB	VerbForm=Inf	18	advcl	18:advcl:to	_
 22	the	the	DET	DT	Definite=Def|PronType=Art	23	det	23:det	_
-23	stategy	stategy	NOUN	NN	Number=Sing	21	obj	21:obj	SpaceAfter=No
+23	stategy	strategy	NOUN	NN	Number=Sing|Typo=Yes	21	obj	21:obj	CorrectForm=strategy|SpaceAfter=No
 24	.	.	PUNCT	.	_	2	punct	2:punct	_
 
 # sent_id = email-enronsent00_01-0017
@@ -42457,7 +42457,7 @@
 # sent_id = email-enronsent30_01-0010
 # newpar id = email-enronsent30_01-p0004
 # text = Monday's starting next week at 4???????????????
-1	Monday's	Monday	PROPN	NNPS	Number=Plur	0	root	0:root	_
+1	Monday's	Monday	PROPN	NNPS	Number=Plur|Typo=Yes	0	root	0:root	CorrectForm=Mondays
 2	starting	start	VERB	VBG	VerbForm=Ger	1	acl	1:acl	_
 3	next	next	ADJ	JJ	Degree=Pos	4	amod	4:amod	_
 4	week	week	NOUN	NN	Number=Sing	2	obl:unmarked	2:obl:unmarked	TemporalNPAdjunct=Yes
@@ -43816,7 +43816,7 @@
 6	2000	2000	NUM	CD	NumForm=Digit|NumType=Card	4	obl	4:obl:in	_
 7	for	for	ADP	IN	_	9	case	9:case	_
 8	the	the	DET	DT	Definite=Def|PronType=Art	9	det	9:det	_
-9	acquistion	acquistion	NOUN	NN	Number=Sing	4	obl	4:obl:for	_
+9	acquistion	acquisition	NOUN	NN	Number=Sing|Typo=Yes	4	obl	4:obl:for	CorrectForm=acquisition
 10	of	of	ADP	IN	_	12	case	12:case	_
 11	WarpSpeed	WarpSpeed	PROPN	NNP	Number=Sing	12	compound	12:compound	_
 12	Communications	Communication	PROPN	NNPS	Number=Plur	9	nmod	9:nmod:of	_
@@ -44739,7 +44739,7 @@
 
 # sent_id = email-enronsent27_01-0022
 # text = Suerat (any works on paper? -
-1	Suerat	Suerat	PROPN	NNP	Number=Sing	0	root	0:root	_
+1	Suerat	Seurat	PROPN	NNP	Number=Sing|Typo=Yes	0	root	0:root	CorrectForm=Seurat
 2	(	(	PUNCT	-LRB-	_	4	punct	4:punct	SpaceAfter=No
 3	any	any	DET	DT	PronType=Ind	4	det	4:det	_
 4	works	work	NOUN	NNS	Number=Plur	1	parataxis	1:parataxis	_
@@ -44788,7 +44788,7 @@
 
 # sent_id = email-enronsent27_01-0029
 # text = Modrian
-1	Modrian	Modrian	PROPN	NNP	Number=Sing	0	root	0:root	_
+1	Modrian	Mondrian	PROPN	NNP	Number=Sing|Typo=Yes	0	root	0:root	CorrectForm=Mondrian
 
 # sent_id = email-enronsent27_01-0030
 # text = Rothko
@@ -45206,7 +45206,7 @@
 3	here	here	ADV	RB	PronType=Dem	0	root	0:root	_
 4	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	3	cop	3:cop	_
 5	the	the	DET	DT	Definite=Def|PronType=Art	7	det	7:det	_
-6	intial	intial	ADJ	JJ	Degree=Pos	7	amod	7:amod	_
+6	intial	initial	ADJ	JJ	Degree=Pos|Typo=Yes	7	amod	7:amod	CorrectForm=initial
 7	draft	draft	NOUN	NN	Number=Sing	3	nsubj	3:nsubj	SpaceAfter=No
 8	.	.	PUNCT	.	_	3	punct	3:punct	_
 
@@ -46487,7 +46487,7 @@
 2	's	's	PART	POS	_	1	case	1:case	_
 3	birthday	birthday	NOUN	NN	Number=Sing	5	nsubj	5:nsubj	_
 4	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	5	cop	5:cop	_
-5	tommorow	tommorow	NOUN	NN	Number=Sing	0	root	0:root	SpaceAfter=No
+5	tommorow	tomorrow	NOUN	NN	Number=Sing|Typo=Yes	0	root	0:root	CorrectForm=tomorrow|SpaceAfter=No
 6	.	.	PUNCT	.	_	5	punct	5:punct	_
 
 # sent_id = email-enronsent08_02-0002
@@ -47276,7 +47276,7 @@
 2	him	he	PRON	PRP	Case=Acc|Gender=Masc|Number=Sing|Person=3|PronType=Prs	1	iobj	1:iobj	_
 3	a	a	DET	DT	Definite=Ind|PronType=Art	4	det	4:det	_
 4	call	call	NOUN	NN	Number=Sing	1	obj	1:obj	_
-5	tommorow	tommorow	NOUN	NN	Number=Sing	1	obl:unmarked	1:obl:unmarked	SpaceAfter=No|TemporalNPAdjunct=Yes
+5	tommorow	tomorrow	NOUN	NN	Number=Sing|Typo=Yes	1	obl:unmarked	1:obl:unmarked	CorrectForm=tomorrow|SpaceAfter=No|TemporalNPAdjunct=Yes
 6	.	.	PUNCT	.	_	1	punct	1:punct	_
 
 # sent_id = email-enronsent08_02-0060
@@ -47369,8 +47369,8 @@
 3-4	didn't	_	_	_	_	_	_	_	_
 3	did	do	AUX	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	5	aux	5:aux	_
 4	n't	not	PART	RB	Polarity=Neg	5	advmod	5:advmod	_
-5	spel	spel	VERB	VB	VerbForm=Inf	0	root	0:root	_
-6	anyting	anyting	NOUN	NN	Number=Sing	5	obj	5:obj	_
+5	spel	spell	VERB	VB	Typo=Yes|VerbForm=Inf	0	root	0:root	CorrectForm=sepll
+6	anyting	anything	NOUN	NN	Number=Sing|Typo=Yes	5	obj	5:obj	CorrectForm=anything
 7	incorrectly	incorrectly	ADV	RB	_	5	advmod	5:advmod	SpaceAfter=No
 8	.	.	PUNCT	.	_	5	punct	5:punct	_
 
@@ -50418,7 +50418,7 @@
 7	Gas	Gas	PROPN	NNP	Number=Sing	4	nmod	4:nmod:at	SpaceAfter=No
 8	-	-	PUNCT	,	_	10	punct	10:punct	SpaceAfter=No
 9	just	just	ADV	RB	_	10	advmod	10:advmod	_
-10	honro	honro	VERB	VB	Mood=Imp|VerbForm=Fin	2	parataxis	2:parataxis	_
+10	honro	honor	VERB	VB	Mood=Imp|Typo=Yes|VerbForm=Fin	2	parataxis	2:parataxis	CorrectForm=honor
 11	his	his	PRON	PRP$	Case=Gen|Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	12	nmod:poss	12:nmod:poss	_
 12	numbers	number	NOUN	NNS	Number=Plur	10	obj	10:obj	_
 
@@ -51580,7 +51580,7 @@
 18	Gray	Gray	PROPN	NNP	Number=Sing	17	flat	17:flat	_
 19	at	at	ADP	IN	_	21	case	21:case	_
 20	Weil	Weil	PROPN	NNP	Number=Sing	21	compound	21:compound	_
-21	Gotschal	Gotschal	PROPN	NNP	Number=Sing	17	nmod	17:nmod:at	_
+21	Gotschal	Gotshal	PROPN	NNP	Number=Sing|Typo=Yes	17	nmod	17:nmod:at	CorrectForm=Gotshal
 22	in	in	ADP	IN	_	23	case	23:case	_
 23	Houston	Houston	PROPN	NNP	Number=Sing	21	nmod	21:nmod:in	_
 24	to	to	PART	TO	_	25	mark	25:mark	_
@@ -52342,7 +52342,7 @@
 1	9	9	NUM	LS	NumForm=Digit|NumType=Card	3	discourse	3:discourse	SpaceAfter=No
 2	.	.	PUNCT	.	_	1	punct	1:punct	_
 3	Scott	Scott	PROPN	NNP	Number=Sing	0	root	0:root	_
-4	McNeally	McNeally	PROPN	NNP	Number=Sing	3	flat	3:flat	SpaceAfter=No
+4	McNeally	McNealy	PROPN	NNP	Number=Sing|Typo=Yes	3	flat	3:flat	CorrectForm=McNealy|SpaceAfter=No
 5	,	,	PUNCT	,	_	6	punct	6:punct	_
 6	CEO	ceo	NOUN	NN	Number=Sing	3	list	3:list	SpaceAfter=No
 7	,	,	PUNCT	,	_	9	punct	9:punct	_
@@ -53122,7 +53122,7 @@
 3	July	July	PROPN	NNP	Number=Sing	4	nmod:unmarked	4:nmod:unmarked	_
 4	12	12	NUM	CD	NumForm=Digit|NumType=Card	1	appos	1:appos	SpaceAfter=No
 5	,	,	PUNCT	,	_	6	punct	6:punct	_
-6	2:300	2:300	NUM	CD	NumForm=Digit|NumType=Card	1	nmod:unmarked	1:nmod:unmarked	TemporalNPAdjunct=Yes
+6	2:300	2:30	NUM	CD	NumForm=Digit|NumType=Card|Typo=Yes	1	nmod:unmarked	1:nmod:unmarked	CorrectForm=2:30|TemporalNPAdjunct=Yes
 7	will	will	AUX	MD	VerbForm=Fin	8	aux	8:aux	_
 8	work	work	VERB	VB	VerbForm=Inf	0	root	0:root	_
 9	for	for	ADP	IN	_	10	case	10:case	_
@@ -53714,7 +53714,7 @@
 5	POA	POA	NOUN	NN	Number=Sing	2	nmod	2:nmod:in	_
 6	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	11	cop	11:cop	_
 7	a	a	DET	DT	Definite=Ind|PronType=Art	11	det	11:det	_
-8	seperate	seperate	ADJ	JJ	Degree=Pos	11	amod	11:amod	_
+8	seperate	separate	ADJ	JJ	Degree=Pos|Typo=Yes	11	amod	11:amod	CorrectForm=separate
 9	and	and	CCONJ	CC	_	10	cc	10:cc	_
 10	distinct	distinct	ADJ	JJ	Degree=Pos	8	conj	8:conj:and|11:amod	_
 11	measure	measure	NOUN	NN	Number=Sing	0	root	0:root	_
@@ -54445,7 +54445,7 @@
 9	future	future	NOUN	NN	Number=Sing	3	nmod	3:nmod:in	SpaceAfter=No
 10	,	,	PUNCT	,	_	3	punct	3:punct	_
 11	the	the	DET	DT	Definite=Def|PronType=Art	16	det	16:det	_
-12	Houson	Houson	PROPN	NNP	Number=Sing	16	compound	16:compound	_
+12	Houson	Houston	PROPN	NNP	Number=Sing|Typo=Yes	16	compound	16:compound	CorrectForm=Houston
 13	and	and	CCONJ	CC	_	14	cc	14:cc	_
 14	London	London	PROPN	NNP	Number=Sing	12	conj	12:conj:and|16:compound	_
 15	credit	credit	NOUN	NN	Number=Sing	16	compound	16:compound	_
@@ -57811,7 +57811,7 @@
 6	at	at	ADP	IN	_	7	case	7:case	_
 7	Index	index	NOUN	NN	Number=Sing	3	obl	3:obl:at	_
 8	and	and	CCONJ	CC	_	9	cc	9:cc	_
-9	sale	sale	VERB	VB	VerbForm=Inf	3	conj	3:conj:and	_
+9	sale	sell	VERB	VB	Typo=Yes|VerbForm=Inf	3	conj	3:conj:and	CorrectForm=sell
 10	Leach	Leach	PROPN	NNP	Number=Sing	9	obj	9:obj	_
 11	or	or	CCONJ	CC	_	12	cc	12:cc	_
 12	Pool	Pool	PROPN	NNP	Number=Sing	10	conj	9:obj|10:conj:or	_
@@ -57865,7 +57865,7 @@
 6	on	on	ADP	IN	_	9	case	9:case	_
 7	the	the	DET	DT	Definite=Def|PronType=Art	9	det	9:det	_
 8	Demand	demand	NOUN	NN	Number=Sing	9	compound	9:compound	_
-9	speadsheet	speadsheet	NOUN	NN	Number=Sing	4	nmod	4:nmod:on	SpaceAfter=No
+9	speadsheet	spreadsheet	NOUN	NN	Number=Sing|Typo=Yes	4	nmod	4:nmod:on	CorrectForm=spreadsheet|SpaceAfter=No
 10	.	.	PUNCT	.	_	2	punct	2:punct	_
 
 # sent_id = email-enronsent11_01-0006
@@ -59135,7 +59135,7 @@
 3	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	4	nsubj	4:nsubj|10:nsubj	_
 4	have	have	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	2	ccomp	2:ccomp	_
 5	your	your	PRON	PRP$	Case=Gen|Person=2|Poss=Yes|PronType=Prs	6	nmod:poss	6:nmod:poss	_
-6	anwser	anwser	NOUN	NN	Number=Sing	4	obj	4:obj	_
+6	anwser	answer	NOUN	NN	Number=Sing|Typo=Yes	4	obj	4:obj	CorrectForm=answer
 7	and	and	CCONJ	CC	_	10	cc	10:cc	_
 8-9	don't	_	_	_	_	_	_	_	_
 8	do	do	AUX	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	10	aux	10:aux	_
@@ -62325,7 +62325,7 @@
 
 # sent_id = email-enronsent15_01-0083
 # text = Tks,
-1	Tks	tks	NOUN	NN	Number=Sing	0	root	0:root	SpaceAfter=No
+1	Tks	thanks	NOUN	NN	Abbr=Yes|Number=Sing	0	root	0:root	SpaceAfter=No
 2	,	,	PUNCT	,	_	1	punct	1:punct	_
 
 # sent_id = email-enronsent15_01-0084
@@ -64734,11 +64734,11 @@
 2	and	and	CCONJ	CC	_	3	cc	3:cc	_
 3	myself	myself	PRON	PRP	Case=Acc|Number=Sing|Person=1|PronType=Prs|Reflex=Yes	1	conj	1:conj:and|5:nsubj|9:nsubj:xsubj	_
 4	are	be	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	5	aux	5:aux	_
-5	planing	plane	VERB	VBG	Tense=Pres|VerbForm=Part	0	root	0:root	_
+5	planing	plan	VERB	VBG	Tense=Pres|Typo=Yes|VerbForm=Part	0	root	0:root	CorrectForm=planning
 6	to	to	PART	TO	_	9	mark	9:mark	_
 7	be	be	AUX	VB	VerbForm=Inf	9	cop	9:cop	_
 8	in	in	ADP	IN	_	9	case	9:case	_
-9	Hoston	Hoston	PROPN	NNP	Number=Sing	5	xcomp	5:xcomp	_
+9	Hoston	Houston	PROPN	NNP	Number=Sing|Typo=Yes	5	xcomp	5:xcomp	CorrectForm=Houston
 10	on	on	ADP	IN	_	11	case	11:case	_
 11	Thursday	Thursday	PROPN	NNP	Number=Sing	9	obl	9:obl:on	_
 12	and	and	CCONJ	CC	_	13	cc	13:cc	_
@@ -65309,7 +65309,7 @@
 6	(	(	PUNCT	-LRB-	_	7	punct	7:punct	SpaceAfter=No
 7	Versailles	versaille	NOUN	NNS	Number=Plur	5	parataxis	5:parataxis	_
 8	or	or	CCONJ	CC	_	9	cc	9:cc	_
-9	Fontainbleu	Fontainbleu	PROPN	NNP	Number=Sing	7	conj	7:conj:or	_
+9	Fontainbleu	Fontainebleu	PROPN	NNP	Number=Sing|Typo=Yes	7	conj	7:conj:or	CorrectForm=Fontainebleu
 10	-	-	PUNCT	,	_	14	punct	14:punct	_
 11	half	half	ADJ	JJ	Degree=Pos|NumForm=Word|NumType=Frac	12	amod	12:amod	_
 12	day	day	NOUN	NN	Number=Sing	14	compound	14:compound	_
@@ -65876,7 +65876,7 @@
 # text = If these amendmnets are agreeable to you can you please print and arrange for execution.
 1	If	if	SCONJ	IN	_	5	mark	5:mark	_
 2	these	this	DET	DT	Number=Plur|PronType=Dem	3	det	3:det	_
-3	amendmnets	amendmnet	NOUN	NNS	Number=Plur	5	nsubj	5:nsubj	_
+3	amendmnets	amendment	NOUN	NNS	Number=Plur|Typo=Yes	5	nsubj	5:nsubj	CorrectForm=amendments
 4	are	be	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	5	cop	5:cop	_
 5	agreeable	agreeable	ADJ	JJ	Degree=Pos	11	advcl	11:advcl:if	CxnElt=11:Conditional-UnspecifiedEpistemic-NoInversion.Protasis
 6	to	to	ADP	IN	_	7	case	7:case	_
@@ -74079,7 +74079,7 @@
 19	to	to	ADP	IN	_	22	case	22:case	_
 20	the	the	DET	DT	Definite=Def|PronType=Art	22	det	22:det	_
 21	Admissions	admission	NOUN	NNS	Number=Plur	22	compound	22:compound	_
-22	commitee	commitee	NOUN	NN	Number=Sing	18	obl	18:obl:to	_
+22	commitee	committee	NOUN	NN	Number=Sing|Typo=Yes	18	obl	18:obl:to	CorrectForm=committee
 23	that	that	SCONJ	IN	_	26	mark	26:mark	_
 24	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	26	nsubj	26:nsubj	_
 25	can	can	AUX	MD	VerbForm=Fin	26	aux	26:aux	_
@@ -74423,7 +74423,7 @@
 19	to	to	ADP	IN	_	22	case	22:case	_
 20	the	the	DET	DT	Definite=Def|PronType=Art	22	det	22:det	_
 21	Admissions	admission	NOUN	NNS	Number=Plur	22	compound	22:compound	_
-22	committment	committment	NOUN	NN	Number=Sing	18	obl	18:obl:to	_
+22	committment	commitment	NOUN	NN	Number=Sing|Typo=Yes	18	obl	18:obl:to	CorrectForm=commitment
 23	that	that	SCONJ	IN	_	26	mark	26:mark	_
 24	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	26	nsubj	26:nsubj	_
 25	can	can	AUX	MD	VerbForm=Fin	26	aux	26:aux	_
@@ -74450,7 +74450,7 @@
 6	to	to	PART	TO	_	7	mark	7:mark	_
 7	continue	continue	VERB	VB	VerbForm=Inf	5	xcomp	5:xcomp	_
 8	our	our	PRON	PRP$	Case=Gen|Number=Plur|Person=1|Poss=Yes|PronType=Prs	9	nmod:poss	9:nmod:poss	_
-9	dialague	dialague	NOUN	NN	Number=Sing	7	obj	7:obj	_
+9	dialague	dialogue	NOUN	NN	Number=Sing|Typo=Yes	7	obj	7:obj	CorrectForm=dialogue
 10	regarding	regard	VERB	VBG	Tense=Pres|VerbForm=Part	11	mark	11:mark	_
 11	creating	create	VERB	VBG	VerbForm=Ger	9	acl	9:acl:regarding	_
 12	an	a	DET	DT	Definite=Ind|PronType=Art	18	det	18:det	_
@@ -74815,7 +74815,7 @@
 33	blend	blend	VERB	VB	VerbForm=Inf	31	advcl	31:advcl:to	_
 34	the	the	DET	DT	Definite=Def|PronType=Art	36	det	36:det	_
 35	two	two	NUM	CD	NumForm=Word|NumType=Card	36	nummod	36:nummod	_
-36	vols	vol	NOUN	NNS	Number=Plur	33	obj	33:obj	SpaceAfter=No
+36	vols	vol	NOUN	NNS	Abbr=Yes|Number=Plur	33	obj	33:obj	SpaceAfter=No
 37	)	)	PUNCT	-RRB-	_	26	punct	26:punct	SpaceAfter=No
 38	?	?	PUNCT	.	_	5	punct	5:punct	_
 
@@ -76711,7 +76711,7 @@
 12	's	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	15	cop	15:cop	_
 13	on	on	ADP	IN	_	15	case	15:case	_
 14	the	the	DET	DT	Definite=Def|PronType=Art	15	det	15:det	_
-15	phonne	phonne	NOUN	NN	Number=Sing	10	acl:relcl	10:acl:relcl	Cxn=rc-red-obl
+15	phonne	phone	NOUN	NN	Number=Sing|Typo=Yes	10	acl:relcl	10:acl:relcl	CorrectForm=phone|Cxn=rc-red-obl
 16	with	with	ADP	IN	_	17	case	17:case	_
 17	Gibson	Gibson	PROPN	NNP	Number=Sing	15	obl	15:obl:with	_
 18	or	or	CCONJ	CC	_	19	cc	19:cc	_
@@ -79198,13 +79198,13 @@
 23	and	and	CCONJ	CC	_	24	cc	24:cc	_
 24	experience	experience	NOUN	NN	Number=Sing	22	conj	19:obj|22:conj:and	_
 25	to	to	PART	TO	_	26	mark	26:mark	_
-26	persue	persue	VERB	VB	VerbForm=Inf	19	advcl	19:advcl:to	_
+26	persue	pursue	VERB	VB	Typo=Yes|VerbForm=Inf	19	advcl	19:advcl:to	CorrectForm=pursue
 27	my	my	PRON	PRP$	Case=Gen|Number=Sing|Person=1|Poss=Yes|PronType=Prs	28	nmod:poss	28:nmod:poss	_
 28	goals	goal	NOUN	NNS	Number=Plur	26	obj	26:obj	_
 29	in	in	ADP	IN	_	32	case	32:case	_
 30	the	the	DET	DT	Definite=Def|PronType=Art	32	det	32:det	_
 31	technology	technology	NOUN	NN	Number=Sing	32	compound	32:compound	_
-32	feild	feild	NOUN	NN	Number=Sing	28	nmod	28:nmod:in	SpaceAfter=No
+32	feild	field	NOUN	NN	Number=Sing|Typo=Yes	28	nmod	28:nmod:in	CorrectForm=field|SpaceAfter=No
 33	.	.	PUNCT	.	_	4	punct	4:punct	_
 
 # sent_id = email-enronsent14_01-0052
@@ -79346,7 +79346,7 @@
 29	in	in	ADP	IN	_	32	case	32:case	_
 30	the	the	DET	DT	Definite=Def|PronType=Art	32	det	32:det	_
 31	technology	technology	NOUN	NN	Number=Sing	32	compound	32:compound	_
-32	feild	feild	NOUN	NN	Number=Sing	28	nmod	28:nmod:in	SpaceAfter=No
+32	feild	field	NOUN	NN	Number=Sing|Typo=Yes	28	nmod	28:nmod:in	CorrectForm=field|SpaceAfter=No
 33	.	.	PUNCT	.	_	4	punct	4:punct	_
 
 # sent_id = email-enronsent14_01-0061
@@ -80287,7 +80287,7 @@
 11	due	due	ADJ	JJ	Degree=Pos|ExtPos=ADP	14	case	14:case	_
 12	to	to	ADP	IN	_	11	fixed	11:fixed	_
 13	previous	previous	ADJ	JJ	Degree=Pos	14	amod	14:amod	_
-14	committments	committment	NOUN	NNS	Number=Plur	8	obl	8:obl:due_to	SpaceAfter=No
+14	committments	commitment	NOUN	NNS	Number=Plur|Typo=Yes	8	obl	8:obl:due_to	CorrectForm=commitments|SpaceAfter=No
 15	.	.	PUNCT	.	_	8	punct	8:punct	_
 
 # newdoc id = email-enronsent41_01
@@ -83676,7 +83676,7 @@
 5	at	at	ADP	IN	_	8	case	8:case	_
 6	your	your	PRON	PRP$	Case=Gen|Person=2|Poss=Yes|PronType=Prs	8	nmod:poss	8:nmod:poss	_
 7	earliest	early	ADJ	JJS	Degree=Sup	8	amod	8:amod	_
-8	convience	convience	NOUN	NN	Number=Sing	4	obl	4:obl:at	_
+8	convience	convenience	NOUN	NN	Number=Sing|Typo=Yes	4	obl	4:obl:at	CorrectForm=convenience
 9	if	if	SCONJ	IN	_	12	mark	12:mark	_
 10	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	12	nsubj	12:nsubj	_
 11	can	can	AUX	MD	VerbForm=Fin	12	aux	12:aux	_
@@ -83937,7 +83937,7 @@
 24	Planning	Planning	PROPN	NNP	Number=Sing	27	compound	27:compound	_
 25	and	and	CCONJ	CC	_	26	cc	26:cc	_
 26	Zoning	Zoning	PROPN	NNP	Number=Sing	24	conj	24:conj:and|27:compound	_
-27	dept	dept	PROPN	NNP	Number=Sing	17	obj	17:obj	_
+27	dept	department	PROPN	NNP	Abbr=Yes|Number=Sing	17	obj	17:obj	_
 28	regarding	regard	VERB	VBG	Tense=Pres|VerbForm=Part	31	case	31:case	_
 29	our	our	PRON	PRP$	Case=Gen|Number=Plur|Person=1|Poss=Yes|PronType=Prs	31	nmod:poss	31:nmod:poss	_
 30	permit	permit	NOUN	NN	Number=Sing	31	compound	31:compound	_
@@ -84126,7 +84126,7 @@
 2	you	you	PRON	PRP	Case=Acc|Person=2|PronType=Prs	1	obj	1:obj	_
 3	for	for	ADP	IN	_	5	case	5:case	_
 4	the	the	DET	DT	Definite=Def|PronType=Art	5	det	5:det	_
-5	invitaion	invitaion	NOUN	NN	Number=Sing	1	obl	1:obl:for	_
+5	invitaion	invitation	NOUN	NN	Number=Sing|Typo=Yes	1	obl	1:obl:for	CorrectForm=invitation
 6	to	to	ADP	IN	_	9	case	9:case	_
 7	the	the	DET	DT	Definite=Def|PronType=Art	9	det	9:det	_
 8	conference	conference	NOUN	NN	Number=Sing	9	compound	9:compound	_
@@ -85233,7 +85233,7 @@
 4	asked	ask	VERB	VBN	Tense=Past|VerbForm=Part	0	root	0:root	_
 5	about	about	ADP	IN	_	10	case	10:case	_
 6	the	the	DET	DT	Definite=Def|PronType=Art	10	det	10:det	_
-7	gtee	gtee	NOUN	NN	Number=Sing	10	compound	10:compound	_
+7	gtee	guarantee	NOUN	NN	Abbr=Yes|Number=Sing	10	compound	10:compound	_
 8	and	and	CCONJ	CC	_	9	cc	9:cc	_
 9	l/c	l/c	NOUN	NN	Number=Sing	7	conj	7:conj:and|10:compound	_
 10	wording	wording	NOUN	NN	Number=Sing	4	obl	4:obl:about	SpaceAfter=No
@@ -85265,7 +85265,7 @@
 5	fax	fax	VERB	VB	Mood=Sub|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	2	ccomp	2:ccomp	_
 6	the	the	DET	DT	Definite=Def|PronType=Art	9	det	9:det	_
 7	revised	revise	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	9	amod	9:amod	_
-8	gtee	gtee	NOUN	NN	Number=Sing	9	compound	9:compound	_
+8	gtee	guarantee	NOUN	NN	Abbr=Yes|Number=Sing	9	compound	9:compound	_
 9	wording	wording	NOUN	NN	Number=Sing	5	obj	5:obj|13:nsubj:pass	_
 10	that	that	PRON	WDT	PronType=Rel	13	nsubj:pass	9:ref	_
 11	has	have	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	13	aux	13:aux	_
@@ -85359,7 +85359,7 @@
 36	one's	one	NOUN	NNS	Number=Plur|Typo=Yes	27	advcl	27:advcl:if	CorrectForm=ones|CxnElt=27:Conditional-UnspecifiedEpistemic-NoInversion.Protasis
 37	issuing	issue	VERB	VBG	VerbForm=Ger	36	acl	36:acl	_
 38	the	the	DET	DT	Definite=Def|PronType=Art	39	det	39:det	_
-39	gtee	gtee	NOUN	NN	Number=Sing	37	obj	37:obj	_
+39	gtee	guarantee	NOUN	NN	Abbr=Yes|Number=Sing	37	obj	37:obj	_
 40	and	and	CCONJ	CC	_	41	cc	41:cc	_
 41	l/c	l/c	NOUN	NN	Number=Sing	39	conj	37:obj|39:conj:and	SpaceAfter=No
 42	.	.	PUNCT	.	_	2	punct	2:punct	_
@@ -85490,7 +85490,7 @@
 
 # sent_id = email-enronsent35_01-0113
 # text = Eleuthra?
-1	Eleuthra	Eleuthra	PROPN	NNP	Number=Sing	0	root	0:root	SpaceAfter=No
+1	Eleuthra	Eleuthera	PROPN	NNP	Number=Sing|Typo=Yes	0	root	0:root	CorrectForm=Eleuthera|SpaceAfter=No
 2	?	?	PUNCT	.	_	1	punct	1:punct	_
 
 # sent_id = email-enronsent35_01-0114
@@ -85952,7 +85952,7 @@
 
 # sent_id = email-enronsent35_01-0146
 # text = tks
-1	tks	tks	NOUN	NN	Number=Sing	0	root	0:root	_
+1	tks	thanks	NOUN	NN	Abbr=Yes|Number=Sing	0	root	0:root	_
 
 # sent_id = email-enronsent35_01-0147
 # newpar id = email-enronsent35_01-p0024
@@ -88853,7 +88853,7 @@
 11	scenario	scenario	NOUN	NN	Number=Sing	0	root	0:root|15:obl	_
 12	where	where	ADV	WRB	PronType=Rel	15	advmod	11:ref	_
 13	a	a	DET	DT	Definite=Ind|PronType=Art	14	det	14:det	_
-14	muni	muni	NOUN	NN	Number=Sing	15	nsubj	15:nsubj|26:nsubj|33:nsubj	_
+14	muni	municipality	NOUN	NN	Abbr=Yes|Number=Sing	15	nsubj	15:nsubj|26:nsubj|33:nsubj	_
 15	does	do	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	11	acl:relcl	11:acl:relcl	Cxn=rc-wh-obl
 16	a	a	DET	DT	Definite=Ind|PronType=Art	18	det	18:det	_
 17	derivative	derivative	NOUN	NN	Number=Sing	18	compound	18:compound	_
@@ -89120,7 +89120,7 @@
 9	the	the	DET	DT	Definite=Def|PronType=Art	12	det	12:det	_
 10	Human	human	ADJ	JJ	Degree=Pos	11	amod	11:amod	_
 11	Resource	resource	NOUN	NN	Number=Sing	12	compound	12:compound	_
-12	dept	dept	NOUN	NN	Number=Sing	13	nsubj	13:nsubj	_
+12	dept	department	NOUN	NN	Abbr=Yes|Number=Sing	13	nsubj	13:nsubj	_
 13	said	say	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	3	conj	3:conj:but	_
 14	that	that	SCONJ	IN	_	25	mark	25:mark	_
 15	if	if	SCONJ	IN	_	21	mark	21:mark	_
@@ -90119,7 +90119,7 @@
 8	should	should	AUX	MD	VerbForm=Fin	9	aux	9:aux	_
 9	be	be	VERB	VB	VerbForm=Inf	0	root	0:root	Cxn=Existential-CopPred-ThereExpl
 10	a	a	DET	DT	Definite=Ind|PronType=Art	11	det	11:det	_
-11	parentheses	parentheses	NOUN	NN	Number=Sing	9	nsubj	9:nsubj	CxnElt=9:Existential-CopPred-ThereExpl.Pivot
+11	parentheses	parenthesis	NOUN	NN	Number=Sing|Typo=Yes	9	nsubj	9:nsubj	CorrectForm=parenthesis|CorrectNumber=Sing|CxnElt=9:Existential-CopPred-ThereExpl.Pivot
 12	after	after	ADP	IN	_	13	case	13:case	_
 13	etc.	etc.	NOUN	FW	Abbr=Yes|Number=Plur	11	nmod	11:nmod:after	_
 14	in	in	ADP	IN	_	17	case	17:case	_
@@ -90300,7 +90300,7 @@
 5	the	the	DET	DT	Definite=Def|PronType=Art	7	det	7:det	_
 6	defined	define	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	7	amod	7:amod	_
 7	term	term	NOUN	NN	Number=Sing	10	nsubj:pass	10:nsubj:pass	_
-8	Govt	govt	NOUN	NN	Number=Sing	9	compound	9:compound	_
+8	Govt	government	NOUN	NN	Abbr=Yes|Number=Sing	9	compound	9:compound	_
 9	Authority	authority	NOUN	NN	Number=Sing	7	appos	7:appos	_
 10	used	use	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	0	root	0:root	Cxn=Interrogative-WHInfo-Direct|CxnElt=10:Interrogative-WHInfo-Direct.Clause|SpaceAfter=No
 11	?	?	PUNCT	.	_	10	punct	10:punct	_
@@ -93780,7 +93780,7 @@
 4	customers	customer	NOUN	NNS	Number=Plur	1	nmod	1:nmod:for	_
 5	were	be	AUX	VBD	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	6	aux:pass	6:aux:pass	_
 6	adjusted	adjust	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	0	root	0:root	_
-7	according	according	ADV	RB	_	6	advmod	6:advmod	SpaceAfter=No
+7	according	accordingly	ADV	RB	Typo=Yes	6	advmod	6:advmod	CorrectForm=accordingly|SpaceAfter=No
 8	.	.	PUNCT	.	_	6	punct	6:punct	_
 
 # sent_id = email-enronsent43_01-0096
@@ -93850,7 +93850,7 @@
 
 # sent_id = email-enronsent43_01-0102
 # text = Monday's are always tough.
-1	Monday's	Monday	PROPN	NNPS	Number=Plur	4	nsubj	4:nsubj	_
+1	Monday's	Monday	PROPN	NNPS	Number=Plur|Typo=Yes	4	nsubj	4:nsubj	CorrectForm=Mondays
 2	are	be	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	4	cop	4:cop	_
 3	always	always	ADV	RB	PronType=Tot	4	advmod	4:advmod	_
 4	tough	tough	ADJ	JJ	Degree=Pos	0	root	0:root	SpaceAfter=No
@@ -97201,7 +97201,7 @@
 4	Joe	Joe	PROPN	NNP	Number=Sing	2	appos	2:appos	_
 5	Deffner	Deffner	PROPN	NNP	Number=Sing	4	flat	4:flat	SpaceAfter=No
 6	,	,	PUNCT	,	_	8	punct	8:punct	_
-7	Brain	Brain	PROPN	NNP	Number=Sing	8	compound	8:compound	_
+7	Brain	Brian	PROPN	NNP	Number=Sing|Typo=Yes	8	compound	8:compound	CorrectForm=Brian
 8	Kerrigan	Kerrigan	PROPN	NNP	Number=Sing	4	conj	2:appos|4:conj	SpaceAfter=No
 9	,	,	PUNCT	,	_	10	punct	10:punct	_
 10	Lewis	Lewis	PROPN	NNP	Number=Sing	4	conj	2:appos|4:conj	_
@@ -97399,7 +97399,7 @@
 8	any	any	DET	DT	PronType=Ind	11	det	11:det	_
 9	bad	bad	ADJ	JJ	Degree=Pos	11	amod	11:amod	_
 10	faith	faith	NOUN	NN	Number=Sing	11	compound	11:compound	_
-11	actins	actin	NOUN	NNS	Number=Plur	6	nmod	6:nmod:of|13:obj	_
+11	actins	action	NOUN	NNS	Number=Plur|Typo=Yes	6	nmod	6:nmod:of|13:obj	CorrectForm=actions
 12	Enron	Enron	PROPN	NNP	Number=Sing	13	nsubj	13:nsubj	_
 13	has	have	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	11	acl:relcl	11:acl:relcl	Cxn=rc-red-obj
 14	pending	pend	VERB	VBG	VerbForm=Ger	11	acl	11:acl	_
@@ -97414,7 +97414,7 @@
 23	who	who	PRON	WP	PronType=Rel	24	nsubj	21:ref	_
 24	manages	manage	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	21	acl:relcl	21:acl:relcl	Cxn=rc-wh-nsubj
 25	domestic	domestic	ADJ	JJ	Degree=Pos	26	amod	26:amod	_
-26	litgation	litgation	NOUN	NN	Number=Sing	24	obj	24:obj	_
+26	litgation	litigation	NOUN	NN	Number=Sing	24	obj	24:obj	CorrectForm=litigation
 27	here	here	ADV	RB	PronType=Dem	26	advmod	26:advmod	SpaceAfter=No
 28	.	.	PUNCT	.	_	4	punct	4:punct	_
 
@@ -98487,7 +98487,7 @@
 2-3	trustee's	_	_	_	_	_	_	_	_
 2	trustee	trustee	NOUN	NN	Number=Sing	5	nmod:poss	5:nmod:poss	_
 3	's	's	PART	POS	_	2	case	2:case	_
-4	oppositon	oppositon	NOUN	NN	Number=Sing	5	compound	5:compound	_
+4	oppositon	opposition	NOUN	NN	Number=Sing|Typo=Yes	5	compound	5:compound	CorrectForm=opposition
 5	papers	paper	NOUN	NNS	Number=Plur	8	nsubj	8:nsubj	_
 6	are	be	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	8	cop	8:cop	_
 7	now	now	ADV	RB	PronType=Dem	8	advmod	8:advmod	_
@@ -99491,7 +99491,7 @@
 7	the	the	DET	DT	Definite=Def|PronType=Art	12	det	12:det	_
 8	mind	mind	NOUN	NN	Number=Sing	9	compound	9:compound	_
 9	numbing	numb	VERB	VBG	VerbForm=Ger	12	amod	12:amod	_
-10	trailor	trailor	NOUN	NN	Number=Sing	11	compound	11:compound	_
+10	trailor	trailer	NOUN	NN	Number=Sing|Typo=Yes	11	compound	11:compound	CorrectForm=trailer
 11	trash	trash	NOUN	NN	Number=Sing	12	compound	12:compound	_
 12	cretins	cretin	NOUN	NNS	Number=Plur	5	obj	5:obj|19:nsubj	_
 13	out	out	ADV	RB	_	14	advmod	14:advmod	_
@@ -99968,7 +99968,7 @@
 5	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	6	cop	6:cop	_
 6	ready	ready	ADJ	JJ	Degree=Pos	2	advcl	2:advcl:like	_
 7	to	to	PART	TO	_	8	mark	8:mark	_
-8	sour	sour	VERB	VB	VerbForm=Inf	6	xcomp	6:xcomp	_
+8	sour	soar	VERB	VB	Typo=Yes|VerbForm=Inf	6	xcomp	6:xcomp	CorrectForm=soar
 9	again	again	ADV	RB	_	8	advmod	8:advmod	_
 10	after	after	ADP	IN	_	13	case	13:case	_
 11	it's	its	PRON	PRP$	Case=Gen|Gender=Neut|Number=Sing|Person=3|Poss=Yes|PronType=Prs|Typo=Yes	13	nmod:poss	13:nmod:poss	CorrectForm=its
@@ -100666,7 +100666,7 @@
 # text = Any major dischord and we all suffer.
 1	Any	any	DET	DT	PronType=Ind	3	det	3:det	_
 2	major	major	ADJ	JJ	Degree=Pos	3	amod	3:amod	_
-3	dischord	dischord	NOUN	NN	Number=Sing	0	root	0:root	_
+3	dischord	discord	NOUN	NN	Number=Sing|Typo=Yes	0	root	0:root	CorrectForm=discord
 4	and	and	CCONJ	CC	_	7	cc	7:cc	_
 5	we	we	PRON	PRP	Case=Nom|Number=Plur|Person=1|PronType=Prs	7	nsubj	7:nsubj	_
 6	all	all	DET	DT	PronType=Tot	7	advmod	7:advmod	_
@@ -101296,7 +101296,7 @@
 7	of	of	ADP	IN	_	8	case	8:case	_
 8	products	product	NOUN	NNS	Number=Plur	6	nmod	6:nmod:of	_
 9	called	call	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	6	acl	6:acl	_
-10	Gelceuticals	gelceutical	NOUN	NNS	Number=Plur	9	obj	9:obj	SpaceAfter=No
+10	Gelceuticals	Gelceutical	NOUN	NNS	Number=Plur	9	obj	9:obj	SpaceAfter=No
 11	.	.	PUNCT	.	_	2	punct	2:punct	_
 
 # sent_id = newsgroup-groups.google.com_eHolistic_417b09016150421f_ENG_20051120_175800-0014
@@ -101329,7 +101329,7 @@
 9	serving	serving	NOUN	NN	Number=Sing	10	compound	10:compound	_
 10	packets	packet	NOUN	NNS	Number=Plur	6	obj	6:obj|7:nsubj:xsubj	_
 11	of	of	ADP	IN	_	12	case	12:case	_
-12	Gelceuticals	gelceutical	NOUN	NNS	Number=Plur	10	nmod	10:nmod:of	SpaceAfter=No
+12	Gelceuticals	Gelceutical	NOUN	NNS	Number=Plur	10	nmod	10:nmod:of	SpaceAfter=No
 13	.	.	PUNCT	.	_	6	punct	6:punct	_
 
 # sent_id = newsgroup-groups.google.com_eHolistic_417b09016150421f_ENG_20051120_175800-0016
@@ -104569,7 +104569,7 @@
 10	comes	come	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	6	advcl	6:advcl:when	_
 11	out	out	ADP	RP	_	10	compound:prt	10:compound:prt	_
 12	in	in	ADP	IN	_	13	case	13:case	_
-13	Febuary	Febuary	PROPN	NNP	Number=Sing	10	obl	10:obl:in	SpaceAfter=No
+13	Febuary	February	PROPN	NNP	Number=Sing|Typo=Yes	10	obl	10:obl:in	CorrectForm=February|SpaceAfter=No
 14	.	.	PUNCT	.	_	6	punct	6:punct	_
 
 # sent_id = newsgroup-groups.google.com_GuildWars_086f0f64ab633ab3_ENG_20041111_173500-0019
@@ -104580,7 +104580,7 @@
 4	05	05	NUM	CD	NumForm=Digit|NumType=Card	2	obj	2:obj	_
 5	on	on	ADP	IN	_	7	case	7:case	_
 6	the	the	DET	DT	Definite=Def|PronType=Art	7	det	7:det	_
-7	calender	calender	NOUN	NN	Number=Sing	2	obl	2:obl:on	SpaceAfter=No
+7	calender	calendar	NOUN	NN	Number=Sing|Typo=Yes	2	obl	2:obl:on	CorrectForm=calendar|SpaceAfter=No
 8	.	.	PUNCT	.	_	2	punct	2:punct	_
 
 # sent_id = newsgroup-groups.google.com_GuildWars_086f0f64ab633ab3_ENG_20041111_173500-0020
@@ -105494,7 +105494,7 @@
 
 # sent_id = newsgroup-groups.google.com_humanities.lit.authors.shakespeare_0c155162a7dfaf28_ENG_20031127_172200-0015
 # text = Unemployent stays low because half the population oversees those "out of the workforce", the dregs, the rabble, the enemy?
-1	Unemployent	unemployent	NOUN	NN	Number=Sing	2	nsubj	2:nsubj|3:nsubj:xsubj	_
+1	Unemployent	unemployment	NOUN	NN	Number=Sing|Typo=Yes	2	nsubj	2:nsubj|3:nsubj:xsubj	CorrectForm=Unemployment
 2	stays	stay	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 3	low	low	ADJ	JJ	Degree=Pos	2	xcomp	2:xcomp	_
 4	because	because	SCONJ	IN	_	8	mark	8:mark	_
@@ -106828,7 +106828,7 @@
 38	company	company	NOUN	NN	Number=Sing	33	nmod	33:nmod:of	SpaceAfter=No
 39	,	,	PUNCT	,	_	41	punct	41:punct	_
 40	and	and	CCONJ	CC	_	41	cc	41:cc	_
-41	Condoleeza	Condoleeza	PROPN	NNP	Number=Sing	11	conj	8:obj|11:conj:and|46:nmod:poss	_
+41	Condoleeza	Condoleezaa	PROPN	NNP	Number=Sing|Typo=Yes	11	conj	8:obj|11:conj:and|46:nmod:poss	CorrectForm=Condoleezaa
 42	Rice	Rice	PROPN	NNP	Number=Sing	41	flat	41:flat	SpaceAfter=No
 43	,	,	PUNCT	,	_	51	punct	51:punct	_
 44	whose	whose	PRON	WP$	Poss=Yes|PronType=Rel	46	nmod:poss	41:ref	_
@@ -109036,9 +109036,10 @@
 24	way	way	NOUN	NN	Number=Sing	11	ccomp	11:ccomp	_
 25	to	to	PART	TO	_	26	mark	26:mark	_
 26	invent	invent	VERB	VB	VerbForm=Inf	24	acl	24:acl:to	_
-27	the	the	DET	DT	Definite=Def|PronType=Art	28	det	28:det	_
-28	cellfone	cellfone	NOUN	NN	Number=Sing	26	obj	26:obj	SpaceAfter=No
-29	?	?	PUNCT	.	_	2	punct	2:punct	_
+27	the	the	DET	DT	Definite=Def|PronType=Art	29	det	29:det	_
+28	cell	cell	NOUN	NN	Number=Sing	29	compound	29:compound	CorrectSpaceAfter=Yes|SpaceAfter=No
+29	fone	phone	NOUN	NN	Number=Sing|Typo=Yes	26	obj	26:obj	CorrectForm=phone|SpaceAfter=No
+30	?	?	PUNCT	.	_	2	punct	2:punct	_
 
 # sent_id = newsgroup-groups.google.com_FOOLED_1bf9cdc5a4c2ac48_ENG_20050904_130400-0057
 # text = and bridges???
@@ -109128,7 +109129,7 @@
 9	but	but	CCONJ	CC	_	12	cc	12:cc	_
 10	we	we	PRON	PRP	Case=Nom|Number=Plur|Person=1|PronType=Prs	12	nsubj	12:nsubj|18:nsubj|20:nsubj:xsubj	_
 11	are	be	AUX	VBP	Mood=Ind|Number=Plur|Person=1|Tense=Pres|VerbForm=Fin	12	cop	12:cop	_
-12	desparate	desparate	ADJ	JJ	Degree=Pos	2	conj	2:conj:but	_
+12	desparate	desperate	ADJ	JJ	Degree=Pos|Typo=Yes	2	conj	2:conj:but	CorrectForm=desperate
 13	in	in	ADP	IN	_	15	case	15:case	_
 14	our	our	PRON	PRP$	Case=Gen|Number=Plur|Person=1|Poss=Yes|PronType=Prs	15	nmod:poss	15:nmod:poss	_
 15	efforts	effort	NOUN	NNS	Number=Plur	12	obl	12:obl:in	_
@@ -109199,7 +109200,7 @@
 13	area	area	NOUN	NN	Number=Sing	10	nmod	10:nmod:in	SpaceAfter=No
 14	,	,	PUNCT	,	_	6	punct	6:punct	_
 15	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	16	aux	16:aux	_
-16	sponoring	sponor	VERB	VBG	Tense=Pres|VerbForm=Part	0	root	0:root	_
+16	sponoring	sponsor	VERB	VBG	Tense=Pres|Typo=Yes|VerbForm=Part	0	root	0:root	CorrectForm=sponsoring
 17	a	a	DET	DT	Definite=Ind|PronType=Art	18	det	18:det	_
 18	benefit	benefit	NOUN	NN	Number=Sing	16	obj	16:obj	_
 19	for	for	ADP	IN	_	22	case	22:case	_
@@ -109317,7 +109318,7 @@
 19	used	use	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	9	advcl	9:advcl:so_that	_
 20	for	for	ADP	IN	_	23	case	23:case	_
 21	a	a	DET	DT	Definite=Ind|PronType=Art	23	det	23:det	_
-22	humanatarian	humanatarian	ADJ	JJ	Degree=Pos	23	amod	23:amod	_
+22	humanatarian	humanitarian	ADJ	JJ	Degree=Pos|Typo=Yes	23	amod	23:amod	CorrectForm=humanitarian
 23	cause	cause	NOUN	NN	Number=Sing	19	obl	19:obl:for	SpaceAfter=No
 24	.	.	PUNCT	.	_	6	punct	6:punct	_
 
@@ -117231,7 +117232,7 @@
 6	this	this	DET	DT	Number=Sing|PronType=Dem	7	det	7:det	_
 7	piece	piece	NOUN	NN	Number=Sing	2	conj	2:conj:and|9:nsubj	SpaceAfter=No
 8	,	,	PUNCT	,	_	2	punct	2:punct	_
-9	effected	effect	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	0:root	_
+9	effected	affect	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|Typo=Yes|VerbForm=Fin	0	root	0:root	CorrectForm=affected
 10	me	I	PRON	PRP	Case=Acc|Number=Sing|Person=1|PronType=Prs	9	obj	9:obj	_
 11	enough	enough	ADV	RB	_	9	advmod	9:advmod	_
 12	to	to	PART	TO	_	13	mark	13:mark	_
@@ -117469,7 +117470,7 @@
 # sent_id = newsgroup-groups.google.com_alt.animals.cat_01ff709c4bf2c60c_ENG_20040418_040100-0059
 # text = --Shrodinger"
 1	--	--	PUNCT	NFP	_	2	punct	2:punct	SpaceAfter=No
-2	Shrodinger	Shrodinger	PROPN	NNP	Number=Sing	0	root	0:root	SpaceAfter=No
+2	Shrodinger	Schrödinger	PROPN	NNP	Number=Sing|Typo=Yes	0	root	0:root	CorrectForm=Schrödinger|SpaceAfter=No
 3	"	"	PUNCT	''	_	2	punct	2:punct	_
 
 # sent_id = newsgroup-groups.google.com_alt.animals.cat_01ff709c4bf2c60c_ENG_20040418_040100-0060
@@ -127005,7 +127006,7 @@
 14	Don	Don	PROPN	NNP	Number=Sing	13	appos	13:appos	_
 15	Adriana	Adriana	PROPN	NNP	Number=Sing	14	flat	14:flat	_
 16	de	de	PROPN	NNP	Number=Sing	14	flat	14:flat	_
-17	Armatho	Armatho	PROPN	NNP	Number=Sing	14	flat	14:flat	SpaceAfter=No
+17	Armatho	Armado	PROPN	NNP	Number=Sing|Typo=Yes	14	flat	14:flat	CorrectForm=Armado|SpaceAfter=No
 18	,	,	PUNCT	,	_	19	punct	19:punct	_
 19	full	full	ADJ	JJ	Degree=Pos	13	amod	13:amod	_
 20	of	of	ADP	IN	_	21	case	21:case	_
@@ -127412,7 +127413,7 @@
 9	)	)	PUNCT	-RRB-	_	6	punct	6:punct	_
 10	was	be	AUX	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	14	cop	14:cop	_
 11	the	the	DET	DT	Definite=Def|PronType=Art	14	det	14:det	_
-12	Portugese	Portugese	ADJ	JJ	Degree=Pos	14	amod	14:amod	_
+12	Portugese	Portuguese	ADJ	JJ	Degree=Pos|Typo=Yes	14	amod	14:amod	CorrectForm=Portuguese
 13	Jewish	Jewish	ADJ	JJ	Degree=Pos	14	amod	14:amod	_
 14	doctor	doctor	NOUN	NN	Number=Sing	0	root	0:root	_
 15	accused	accuse	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	14	acl	14:acl	_
@@ -127633,7 +127634,7 @@
 12	)	)	PUNCT	-RRB-	_	7	punct	7:punct	_
 13	born	bear	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	1	parataxis	1:parataxis	_
 14	in	in	ADP	IN	_	15	case	15:case	_
-15	Calaria	Calaria	PROPN	NNP	Number=Sing	13	obl	13:obl:in	SpaceAfter=No
+15	Calaria	Calabria	PROPN	NNP	Number=Sing|Typo=Yes	13	obl	13:obl:in	CorrectForm=Calabria|SpaceAfter=No
 16	.	.	PUNCT	.	_	1	punct	1:punct	_
 
 # sent_id = newsgroup-groups.google.com_humanities.lit.authors.shakespeare_0018a7697318f71f_ENG_20031006_163200-0058
@@ -127815,7 +127816,7 @@
 9	in	in	ADP	IN	_	10	case	10:case	_
 10	presence	presence	NOUN	NN	Number=Sing	5	obl	5:obl:in	_
 11	of	of	ADP	IN	_	12	case	12:case	_
-12	Phillip	Phillip	PROPN	NNP	Number=Sing	10	nmod	10:nmod:of	FlatType=Enumerated
+12	Phillip	Philip	PROPN	NNP	Number=Sing|Typo=Yes	10	nmod	10:nmod:of	CorrectForm=Philip|FlatType=Enumerated
 13	II	II	NUM	CD	NumForm=Roman|NumType=Card	12	flat	12:flat	SpaceAfter=No
 14	.	.	PUNCT	.	_	5	punct	5:punct	_
 
@@ -128291,7 +128292,7 @@
 1	Of	of	ADP	IN	_	5	case	5:case	_
 2	all	all	DET	DT	PronType=Tot	5	det	5:det	_
 3	Freemason	Freemason	PROPN	NNP	Number=Sing	4	compound	4:compound	_
-4	sponsered	sponser	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	5	amod	5:amod	_
+4	sponsered	sponsor	VERB	VBN	Tense=Past|Typo=Yes|VerbForm=Part|Voice=Pass	5	amod	5:amod	CorrectForm=sponsored
 5	revolutions	revolution	NOUN	NNS	Number=Plur	23	obl	23:obl:of	SpaceAfter=No
 6	:	:	PUNCT	:	_	7	punct	7:punct	_
 7	American	American	ADJ	JJ	Degree=Pos	5	amod	5:amod	SpaceAfter=No
@@ -141498,7 +141499,7 @@
 # sent_id = answers-20111108084119AAhsBk8_ans-0007
 # newpar id = answers-20111108084119AAhsBk8_ans-p0004
 # text = cynangon mod should work.
-1	cynangon	Cynangon	PROPN	NNP	Number=Sing	2	compound	2:compound	_
+1	cynangon	Cyanogen	PROPN	NNP	Number=Sing|Typo=Yes	2	compound	2:compound	CorrectForm=Cyanogen
 2	mod	Mod	PROPN	NNP	Number=Sing	4	nsubj	4:nsubj	_
 3	should	should	AUX	MD	VerbForm=Fin	4	aux	4:aux	_
 4	work	work	VERB	VB	VerbForm=Inf	0	root	0:root	SpaceAfter=No
@@ -143484,7 +143485,7 @@
 11	i	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	12	nsubj	12:nsubj	_
 12	live	live	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	2	conj	2:conj:and	_
 13	in	in	ADP	IN	_	14	case	14:case	_
-14	forida	forida	PROPN	NNP	Number=Sing	12	obl	12:obl:in	SpaceAfter=No
+14	forida	Florida	PROPN	NNP	Number=Sing|Typo=Yes	12	obl	12:obl:in	CorrectForm=Florida|SpaceAfter=No
 15	.	.	PUNCT	.	_	2	punct	2:punct	_
 
 # sent_id = answers-20111108105225AAAJ9ek_ans-0004
@@ -144286,7 +144287,7 @@
 35	it	it	PRON	PRP	Case=Nom|Gender=Neut|Number=Sing|Person=3|PronType=Prs	36	nsubj	36:nsubj	_
 36	work	work	VERB	VB	VerbForm=Inf	19	conj	16:xcomp|19:conj:and	_
 37	like	like	ADP	IN	_	38	case	38:case	_
-38	normall	normall	ADJ	JJ	Degree=Pos	36	obl	36:obl:like	SpaceAfter=No
+38	normall	normal	ADJ	JJ	Degree=Pos|Typo=Yes	36	obl	36:obl:like	CorrectForm=normal|SpaceAfter=No
 39	?	?	PUNCT	.	_	2	punct	2:punct	SpaceAfter=No
 
 # sent_id = answers-20111108104015AAGxHNm_ans-0003
@@ -145725,7 +145726,7 @@
 # newpar id = answers-20111108082505AAtbdh9_ans-p0005
 # text = hey kido u made me smile
 1	hey	hey	INTJ	UH	_	2	discourse	2:discourse	_
-2	kido	kido	NOUN	NN	Number=Sing	4	vocative	4:vocative	_
+2	kido	kiddo	NOUN	NN	Number=Sing|Typo=Yes	4	vocative	4:vocative	CorrectForm=kiddo
 3	u	you	PRON	PRP	Abbr=Yes|Case=Nom|Person=2|PronType=Prs	4	nsubj	4:nsubj	CorrectForm=you
 4	made	make	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	0:root	_
 5	me	I	PRON	PRP	Case=Acc|Number=Sing|Person=1|PronType=Prs	4	obj	4:obj|6:nsubj:xsubj	_
@@ -146522,12 +146523,12 @@
 15	graduated	graduate	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	4	conj	4:conj:and	_
 16	from	from	ADP	IN	_	17	case	17:case	_
 17	high	high	ADJ	JJ	Degree=Pos	15	obl	15:obl:from	_
-18	in	in	ADP	IN	_	20	case	20:case	_
-19	May	May	PROPN	NNP	Number=Sing	20	compound	20:compound	_
-20	adn	adn	NOUN	NN	Number=Sing	15	obl	15:obl:in	_
+18	in	in	ADP	IN	_	19	case	19:case	_
+19	May	May	PROPN	NNP	Number=Sing	15	obl	15:obl:in	_
+20	adn	adn	NOUN	NN	Number=Sing	23	reparandum	23:reparandum	_
 21	of	of	ADP	IN	_	23	case	23:case	_
 22	this	this	DET	DT	Number=Sing|PronType=Dem	23	det	23:det	_
-23	year	year	NOUN	NN	Number=Sing	20	nmod	20:nmod:of	_
+23	year	year	NOUN	NN	Number=Sing	19	nmod	19:nmod:of	_
 24	and	and	CCONJ	CC	_	26	cc	26:cc	_
 25	i	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	26	nsubj	26:nsubj	_
 26	love	love	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	4	conj	4:conj:and	_
@@ -147213,7 +147214,7 @@
 
 # sent_id = answers-20111108100523AA1i7no_ans-0010
 # text = Aquiriums are good also, but provide a mesh top for an easy airway.
-1	Aquiriums	aquirium	NOUN	NNS	Number=Plur	3	nsubj	3:nsubj|7:nsubj	_
+1	Aquiriums	aquarium	NOUN	NNS	Number=Plur|Typo=Yes	3	nsubj	3:nsubj|7:nsubj	CorrectForm=Aquariums
 2	are	be	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	3	cop	3:cop	_
 3	good	good	ADJ	JJ	Degree=Pos	0	root	0:root	_
 4	also	also	ADV	RB	_	3	advmod	3:advmod	SpaceAfter=No
@@ -147318,7 +147319,7 @@
 9	leave	leave	VERB	VB	VerbForm=Inf	7	xcomp	7:xcomp	_
 10	this	this	DET	DT	Number=Sing|PronType=Dem	12	det	12:det	_
 11	whole	whole	ADJ	JJ	Degree=Pos	12	amod	12:amod	_
-12	enviroment	enviroment	NOUN	NN	Number=Sing	9	obj	9:obj	SpaceAfter=No
+12	enviroment	environment	NOUN	NN	Number=Sing|Typo=Yes	9	obj	9:obj	CorrectForm=environment|SpaceAfter=No
 13	.	.	PUNCT	.	_	2	punct	2:punct	_
 
 # sent_id = answers-20111107212131AACQ65F_ans-0005
@@ -147936,7 +147937,7 @@
 1	Why	why	ADV	WRB	PronType=Int	5	advmod	5:advmod	CxnElt=5:Interrogative-WHInfo-Direct.WHWord
 2	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	5	aux	5:aux	_
 3	it	it	PRON	PRP	Case=Nom|Gender=Neut|Number=Sing|Person=3|PronType=Prs	5	nsubj	5:nsubj	_
-4	stil	stil	ADV	RB	_	5	advmod	5:advmod	_
+4	stil	still	ADV	RB	Typo=Yes	5	advmod	5:advmod	CorrectForm=still
 5	doing	do	VERB	VBG	Tense=Pres|VerbForm=Part	0	root	0:root	Cxn=Interrogative-WHInfo-Direct|CxnElt=5:Interrogative-WHInfo-Direct.Clause
 6	this	this	PRON	DT	Number=Sing|PronType=Dem	5	obj	5:obj	_
 7	even	even	ADV	RB	_	12	advmod	12:advmod	_
@@ -149450,7 +149451,7 @@
 19	Everland	Everland	PROPN	NNP	Number=Sing	17	conj	13:appos|17:conj:and	SpaceAfter=No
 20	,	,	PUNCT	,	_	23	punct	23:punct	_
 21	and	and	CCONJ	CC	_	23	cc	23:cc	_
-22	Carribbean	Carribbean	PROPN	NNP	Number=Sing	23	compound	23:compound	_
+22	Carribbean	Caribbean	PROPN	NNP	Number=Sing|Typo=Yes	23	compound	23:compound	CorrectForm=Caribbean
 23	Bay	Bay	PROPN	NNP	Number=Sing	17	conj	13:appos|17:conj:and	SpaceAfter=No
 24	!	!	PUNCT	.	_	5	punct	5:punct	_
 
@@ -149512,7 +149513,7 @@
 
 # sent_id = answers-20111108110610AA4bcXX_ans-0015
 # text = Carribbean Bay: http://tong.visitkorea.or.kr/cms/resource/81/188181_image2_1.jpg
-1	Carribbean	Carribbean	PROPN	NNP	Number=Sing	2	compound	2:compound	_
+1	Carribbean	Caribbean	PROPN	NNP	Number=Sing|Typo=Yes	2	compound	2:compound	CorrectForm=Caribbean
 2	Bay	Bay	PROPN	NNP	Number=Sing	0	root	0:root	SpaceAfter=No
 3	:	:	PUNCT	:	_	4	punct	4:punct	_
 4	http://tong.visitkorea.or.kr/cms/resource/81/188181_image2_1.jpg	http://tong.visitkorea.or.kr/cms/resource/81/188181_image2_1.jpg	PROPN	ADD	_	2	appos	2:appos	_
@@ -150295,7 +150296,7 @@
 6	please	please	INTJ	UH	_	7	discourse	7:discourse	_
 7	list	list	VERB	VB	Mood=Imp|VerbForm=Fin	0	root	0:root	_
 8	:)	:)	SYM	NFP	_	9	discourse	9:discourse	_
-9	Thx	thx	NOUN	NN	Number=Sing	7	discourse	7:discourse	_
+9	Thx	thanks	NOUN	NN	Abbr=Yes|Number=Sing	7	discourse	7:discourse	_
 
 # sent_id = answers-20111108080100AAJHNUK_ans-0007
 # newpar id = answers-20111108080100AAJHNUK_ans-p0003
@@ -150376,7 +150377,7 @@
 11	make	make	VERB	VB	VerbForm=Inf	1	parataxis	1:parataxis	_
 12	your	your	PRON	PRP$	Case=Gen|Person=2|Poss=Yes|PronType=Prs	13	nmod:poss	13:nmod:poss	_
 13	image	image	NOUN	NN	Number=Sing	11	obj	11:obj|14:nsubj:xsubj|16:nsubj:xsubj	_
-14	blak	blak	ADJ	JJ	Degree=Pos	11	xcomp	11:xcomp	_
+14	blak	black	ADJ	JJ	Degree=Pos|Typo=Yes	11	xcomp	11:xcomp	CorrectForm=black
 15	and	and	CCONJ	CC	_	16	cc	16:cc	_
 16	white	white	ADJ	JJ	Degree=Pos	14	conj	11:xcomp|14:conj:and	SpaceAfter=No
 17	.	.	PUNCT	.	_	1	punct	1:punct	_
@@ -150664,7 +150665,7 @@
 13	this	this	DET	DT	Number=Sing|PronType=Dem	14	det	14:det	_
 14	procedure	procedure	NOUN	NN	Number=Sing	12	obj	12:obj	_
 15	like	like	ADP	IN	_	17	case	17:case	_
-16	Bumrungard	Bumrungard	PROPN	NNP	Number=Sing	17	compound	17:compound	_
+16	Bumrungard	Bumrungrad	PROPN	NNP	Number=Sing|Typo=Yes	17	compound	17:compound	CorrectForm=Bumrungrad
 17	Hospital	Hospital	PROPN	NNP	Number=Sing	6	nmod	6:nmod:like	_
 18	or	or	CCONJ	CC	_	20	cc	20:cc	_
 19	Yanhee	Yanhee	PROPN	NNP	Number=Sing	20	compound	20:compound	_
@@ -152661,7 +152662,7 @@
 # text = Lights are optinal since fish need the light turn off at night anyways and an air pump is not nessasary since they get air from the surface.
 1	Lights	light	NOUN	NNS	Number=Plur	3	nsubj	3:nsubj	_
 2	are	be	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	3	cop	3:cop	_
-3	optinal	optinal	ADJ	JJ	Degree=Pos	0	root	0:root	_
+3	optinal	optional	ADJ	JJ	Degree=Pos|Typo=Yes	0	root	0:root	CorrectForm=optional
 4	since	since	SCONJ	IN	_	6	mark	6:mark	_
 5	fish	fish	NOUN	NNS	Number=Plur	6	nsubj	6:nsubj	_
 6	need	need	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	3	advcl	3:advcl:since	_
@@ -152678,7 +152679,7 @@
 17	pump	pump	NOUN	NN	Number=Sing	20	nsubj	20:nsubj	_
 18	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	20	cop	20:cop	_
 19	not	not	PART	RB	Polarity=Neg	20	advmod	20:advmod	_
-20	nessasary	nessasary	ADJ	JJ	Degree=Pos	3	conj	3:conj:and	_
+20	nessasary	necessary	ADJ	JJ	Degree=Pos|Typo=Yes	3	conj	3:conj:and	CorrectForm=necessary
 21	since	since	SCONJ	IN	_	23	mark	23:mark	_
 22	they	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	23	nsubj	23:nsubj	_
 23	get	get	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	20	advcl	20:advcl:since	_
@@ -152789,7 +152790,7 @@
 3	possible	possible	ADJ	JJ	Degree=Pos	0	root	0:root	_
 4	to	to	PART	TO	_	5	mark	5:mark	_
 5	shoot	shoot	VERB	VB	VerbForm=Inf	3	csubj	3:csubj	_
-6	lazers	lazer	NOUN	NNS	Number=Plur	5	obj	5:obj	_
+6	lazers	laser	NOUN	NNS	Number=Plur|Typo=Yes	5	obj	5:obj	CorrectForm=lasers
 7	out	out	ADP	IN	_	10	case	10:case	_
 8	of	of	ADP	IN	_	10	case	10:case	_
 9	your	your	PRON	PRP$	Case=Gen|Person=2|Poss=Yes|PronType=Prs	10	nmod:poss	10:nmod:poss	_
@@ -153987,7 +153988,7 @@
 13	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	16	aux	16:aux	_
 14	also	also	ADV	RB	_	16	advmod	16:advmod	_
 15	not	not	PART	RB	Polarity=Neg	16	advmod	16:advmod	_
-16	useing	usee	VERB	VBG	Tense=Pres|VerbForm=Part	6	parataxis	6:parataxis	_
+16	useing	use	VERB	VBG	Tense=Pres|Typo=Yes|VerbForm=Part	6	parataxis	6:parataxis	CorrectForm=using
 17	the	the	DET	DT	Definite=Def|PronType=Art	18	det	18:det	_
 18	thing	thing	NOUN	NN	Number=Sing	16	obj	16:obj|21:obl	_
 19	that	that	PRON	WDT	PronType=Rel	21	obl	18:ref	_
@@ -155953,7 +155954,7 @@
 48	,	,	PUNCT	,	_	49	punct	49:punct	_
 49	paper	paper	NOUN	NN	Number=Sing	36	conj	36:conj	SpaceAfter=No
 50	,	,	PUNCT	,	_	52	punct	52:punct	_
-51	bryer	bryer	NOUN	NN	Number=Sing	52	compound	52:compound	_
+51	bryer	Breyer	NOUN	NN	Number=Sing|Typo=Yes	52	compound	52:compound	CorrectForm=Breyer
 52	horses	horse	NOUN	NNS	Number=Plur	36	conj	36:conj	_
 
 # sent_id = answers-20111108065707AAj7DaH_ans-0015
@@ -156768,7 +156769,7 @@
 5	And	and	CCONJ	CC	_	9	cc	9:cc	_
 6	The	the	DET	DT	Definite=Def|PronType=Art	8	det	8:det	_
 7	Rat	Rat	PROPN	NNP	Number=Sing	8	compound	8:compound	_
-8	Calculater	calculater	NOUN	NN	Number=Sing	9	nsubj	9:nsubj	_
+8	Calculater	calculator	NOUN	NN	Number=Sing|Typo=Yes	9	nsubj	9:nsubj	CorrectForm=calculator
 9	Says	say	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	4	conj	4:conj:and	_
 10	Is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	11	cop	11:cop	_
 11	Big	big	ADJ	JJ	Degree=Pos	9	ccomp	9:ccomp	_
@@ -158853,7 +158854,7 @@
 4	to	to	PART	TO	_	5	mark	5:mark	_
 5	go	go	VERB	VB	VerbForm=Inf	3	csubj	3:csubj	_
 6	to	to	ADP	IN	_	7	case	7:case	_
-7	Rotarua	Rotarua	PROPN	NNP	Number=Sing	5	obl	5:obl:to	SpaceAfter=No
+7	Rotarua	Rotorua	PROPN	NNP	Number=Sing|Typo=Yes	5	obl	5:obl:to	CorrectForm=Rotorua|SpaceAfter=No
 8	,	,	PUNCT	,	_	11	punct	11:punct	_
 9	since	since	ADP	IN	_	11	case	11:case	_
 10	the	the	DET	DT	Definite=Def|PronType=Art	11	det	11:det	_
@@ -158896,7 +158897,7 @@
 22	so	so	ADV	RB	_	25	advmod	25:advmod	_
 23	nothing	nothing	PRON	NN	Number=Sing|PronType=Neg	25	nsubj:pass	25:nsubj:pass	_
 24	was	be	AUX	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	25	aux:pass	25:aux:pass	_
-25	effected	effect	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	15	parataxis	15:parataxis	_
+25	effected	affect	VERB	VBN	Tense=Past|Typo=Yes|VerbForm=Part|Voice=Pass	15	parataxis	15:parataxis	CorrectForm=affected
 26	:)	:)	SYM	NFP	_	3	discourse	3:discourse	_
 
 # sent_id = answers-20111108094504AAKrc8F_ans-0009
@@ -159044,7 +159045,7 @@
 22	how	how	ADV	WRB	PronType=Int	25	advmod	25:advmod	CxnElt=25:Interrogative-WHInfo-Indirect.WHWord
 23	things	thing	NOUN	NNS	Number=Plur	25	nsubj:pass	25:nsubj:pass	_
 24	get	get	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	25	aux:pass	25:aux:pass	_
-25	effected	effect	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	19	ccomp	19:ccomp	Cxn=Interrogative-WHInfo-Indirect|CxnElt=25:Interrogative-WHInfo-Indirect.Clause
+25	effected	affect	VERB	VBN	Tense=Past|Typo=Yes|VerbForm=Part|Voice=Pass	19	ccomp	19:ccomp	CorrectForm=affected|Cxn=Interrogative-WHInfo-Indirect|CxnElt=25:Interrogative-WHInfo-Indirect.Clause
 26	by	by	ADP	IN	_	27	case	27:case	_
 27	earthquakes	earthquake	NOUN	NNS	Number=Plur	25	obl:agent	25:obl:agent	SpaceAfter=No
 28	.	.	PUNCT	.	_	6	punct	6:punct	_
@@ -160438,7 +160439,7 @@
 14	the	the	DET	DT	Definite=Def|PronType=Art	17	det	17:det	_
 15	most	most	ADV	RBS	Degree=Sup	16	advmod	16:advmod	_
 16	amazing	amazing	ADJ	JJ	Degree=Pos	17	amod	17:amod	_
-17	experice	experice	NOUN	NN	Number=Sing	2	conj	2:conj:and	_
+17	experice	experience	NOUN	NN	Number=Sing|Typo=Yes	2	conj	2:conj:and	CorrectForm=experience
 18	of	of	ADP	IN	_	20	case	20:case	_
 19	my	my	PRON	PRP$	Case=Gen|Number=Sing|Person=1|Poss=Yes|PronType=Prs	20	nmod:poss	20:nmod:poss	_
 20	upbringing	upbringing	NOUN	NN	Number=Sing	17	nmod	17:nmod:of	SpaceAfter=No
@@ -161079,7 +161080,7 @@
 7	,	,	PUNCT	,	_	10	punct	10:punct	_
 8	perfect	perfect	ADJ	JJ	Degree=Pos	10	amod	10:amod	_
 9	water	water	NOUN	NN	Number=Sing	10	compound	10:compound	_
-10	conditons	conditon	NOUN	NNS	Number=Plur	2	conj	2:conj:and	_
+10	conditons	condition	NOUN	NNS	Number=Plur|Typo=Yes	2	conj	2:conj:and	CorrectForm=conditions
 11	and	and	CCONJ	CC	_	14	cc	14:cc	_
 12	really	really	ADV	RB	_	13	advmod	13:advmod	_
 13	good	good	ADJ	JJ	Degree=Pos	14	amod	14:amod	_
@@ -161825,7 +161826,7 @@
 5	for	for	ADP	IN	_	9	case	9:case	_
 6	canada	Canada	PROPN	NNP	Number=Sing	9	compound	9:compound	_
 7	skilled	skill	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	8	amod	8:amod	_
-8	immigeration	immigeration	NOUN	NN	Number=Sing	9	compound	9:compound	_
+8	immigeration	immigration	NOUN	NN	Number=Sing|Typo=Yes	9	compound	9:compound	CorrectForm=immigration
 9	program	program	NOUN	NN	Number=Sing	4	obl	4:obl:for	SpaceAfter=No
 10	.	.	PUNCT	.	_	2	punct	2:punct	SpaceAfter=No
 
@@ -161838,7 +161839,7 @@
 5	points	point	NOUN	NNS	Number=Plur	2	obj	2:obj	_
 6	while	while	SCONJ	IN	_	10	mark	10:mark	_
 7	67	67	NUM	CD	NumForm=Digit|NumType=Card	10	nsubj	10:nsubj	_
-8	minimunm	minimunm	NOUN	NN	Number=Sing	7	nmod:unmarked	7:nmod:unmarked	_
+8	minimunm	minimum	NOUN	NN	Number=Sing|Typo=Yes	7	nmod:unmarked	7:nmod:unmarked	CorrectForm=minimum
 9	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	10	cop	10:cop	_
 10	requirement	requirement	NOUN	NN	Number=Sing	2	advcl	2:advcl:while	SpaceAfter=No
 11	.?	.?	PUNCT	.	_	2	punct	2:punct	_
@@ -162342,7 +162343,7 @@
 17	)	)	PUNCT	-RRB-	_	4	punct	4:punct	_
 18	so	so	ADV	RB	_	21	advmod	21:advmod	_
 19	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	21	nsubj	21:nsubj	_
-20	fineally	fineally	ADV	RB	_	21	advmod	21:advmod	_
+20	fineally	finally	ADV	RB	Typo=Yes	21	advmod	21:advmod	CorrectForm=finally
 21	checked	check	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	4	parataxis	4:parataxis	_
 22	it	it	PRON	PRP	Case=Acc|Gender=Neut|Number=Sing|Person=3|PronType=Prs	21	obj	21:obj	SpaceAfter=No
 23	,	,	PUNCT	,	_	28	punct	28:punct	_
@@ -163868,7 +163869,7 @@
 9	,	,	PUNCT	,	_	12	punct	12:punct	_
 10	which	which	PRON	WDT	PronType=Rel	12	nsubj	8:ref	_
 11	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	12	cop	12:cop	_
-12	dominate	dominate	ADJ	JJ	Degree=Pos	8	acl:relcl	8:acl:relcl	Cxn=rc-wh-nsubj|SpaceAfter=No
+12	dominate	dominant	ADJ	JJ	Degree=Pos|Typo=Yes	8	acl:relcl	8:acl:relcl	CorrectForm=dominant|Cxn=rc-wh-nsubj|SpaceAfter=No
 13	.	.	PUNCT	.	_	2	punct	2:punct	_
 
 # sent_id = answers-20111108092029AAsHTYP_ans-0013
@@ -163882,7 +163883,7 @@
 7	be	be	AUX	VB	VerbForm=Inf	8	cop	8:cop	_
 8	recessive	recessive	ADJ	JJ	Degree=Pos	4	acl:relcl	4:acl:relcl	Cxn=rc-wh-nsubj
 9	or	or	CCONJ	CC	_	10	cc	10:cc	_
-10	dominate	dominate	ADJ	JJ	Degree=Pos	8	conj	4:acl:relcl|8:conj:or	SpaceAfter=No
+10	dominate	dominant	ADJ	JJ	Degree=Pos|Typo=Yes	8	conj	4:acl:relcl|8:conj:or	CorrectForm=dominant|SpaceAfter=No
 11	.	.	PUNCT	.	_	2	punct	2:punct	_
 
 # sent_id = answers-20111108092029AAsHTYP_ans-0014
@@ -163941,7 +163942,7 @@
 24	genes	gene	NOUN	NNS	Number=Plur	27	nsubj	27:nsubj	_
 25	are	be	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	27	cop	27:cop	_
 26	incomplete	incomplete	ADV	RB	_	27	advmod	27:advmod	_
-27	dominate	dominate	ADJ	JJ	Degree=Pos	16	advcl	16:advcl:as	SpaceAfter=No
+27	dominate	dominant	ADJ	JJ	Degree=Pos|Typo=Yes	16	advcl	16:advcl:as	CorrectForm=dominant|SpaceAfter=No
 28	.	.	PUNCT	.	_	3	punct	3:punct	_
 
 # sent_id = answers-20111108092029AAsHTYP_ans-0017
@@ -163963,7 +163964,7 @@
 15	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	18	cop	18:cop	_
 16	also	also	ADV	RB	_	18	advmod	18:advmod	_
 17	incomplete	incomplete	ADV	RB	_	18	advmod	18:advmod	_
-18	dominate	dominate	ADJ	JJ	Degree=Pos	8	advcl	8:advcl:as	SpaceAfter=No
+18	dominate	dominant	ADJ	JJ	Degree=Pos|Typo=Yes	8	advcl	8:advcl:as	CorrectForm=dominant|SpaceAfter=No
 19	.	.	PUNCT	.	_	2	punct	2:punct	_
 
 # sent_id = answers-20111108092029AAsHTYP_ans-0018
@@ -163983,7 +163984,7 @@
 13	being	be	AUX	VBG	Tense=Pres|VerbForm=Part	17	cop	17:cop	_
 14	another	another	DET	DT	PronType=Ind	17	det	17:det	_
 15	incomplete	incomplete	ADV	RB	_	17	advmod	17:advmod	_
-16	dominate	dominate	ADJ	JJ	Degree=Pos	17	amod	17:amod	_
+16	dominate	dominant	ADJ	JJ	Degree=Pos|Typo=Yes	17	amod	17:amod	CorrectForm=dominant
 17	gene	gene	NOUN	NN	Number=Sing	6	advcl	6:advcl:due_to	SpaceAfter=No
 18	.	.	PUNCT	.	_	1	punct	1:punct	_
 
@@ -164069,7 +164070,7 @@
 5	toes	toe	NOUN	NNS	Number=Plur	8	nsubj	8:nsubj	_
 6	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	8	cop	8:cop	_
 7	incompletely	incompletely	ADV	RB	_	8	advmod	8:advmod	_
-8	dominate	dominate	ADJ	JJ	Degree=Pos	12	parataxis	12:parataxis	SpaceAfter=No
+8	dominate	dominant	ADJ	JJ	Degree=Pos|Typo=Yes	12	parataxis	12:parataxis	CorrectForm=dominant|SpaceAfter=No
 9	)	)	PUNCT	-RRB-	_	8	punct	8:punct	_
 10	chicks	chick	NOUN	NNS	Number=Plur	12	nsubj	12:nsubj	_
 11	could	could	AUX	MD	VerbForm=Fin	12	aux	12:aux	_
@@ -164719,7 +164720,7 @@
 13	respects	respects	NOUN	NNS	Number=Ptan	11	obj	11:obj	_
 14	to	to	ADP	IN	_	16	case	16:case	_
 15	the	the	DET	DT	Definite=Def|PronType=Art	16	det	16:det	_
-16	desisted	desisted	ADJ	JJ	Degree=Pos	11	obl	11:obl:to	_
+16	desisted	deceased	ADJ	JJ	Degree=Pos|Typo=Yes	11	obl	11:obl:to	CorrectForm=deceased
 17	and	and	CCONJ	CC	_	19	cc	19:cc	_
 18	their	their	PRON	PRP$	Case=Gen|Number=Plur|Person=3|Poss=Yes|PronType=Prs	19	nmod:poss	19:nmod:poss	_
 19	family	family	NOUN	NN	Number=Sing	16	conj	11:obl:to|16:conj:and	_
@@ -164912,7 +164913,7 @@
 10	and	and	CCONJ	CC	_	19	cc	19:cc	_
 11	at	at	ADP	IN	_	13	case	13:case	_
 12	the	the	DET	DT	Definite=Def|PronType=Art	13	det	13:det	_
-13	hight	hight	NOUN	NN	Number=Sing	19	obl	19:obl:at	_
+13	hight	height	NOUN	NN	Number=Sing|Typo=Yes	19	obl	19:obl:at	CorrectForm=height
 14	of	of	ADP	IN	_	17	case	17:case	_
 15	the	the	DET	DT	Definite=Def|PronType=Art	17	det	17:det	_
 16	organization	organization	NOUN	NN	Number=Sing	17	compound	17:compound	_
@@ -165046,7 +165047,7 @@
 10	;	;	PUNCT	,	_	9	punct	9:punct	_
 11	we	we	PRON	PRP	Case=Nom|Number=Plur|Person=1|PronType=Prs	12	nsubj	12:nsubj	_
 12	make	make	VERB	VBP	Mood=Ind|Number=Plur|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	_
-13	sinnel	sinnel	NOUN	NN	Number=Sing	14	compound	14:compound	_
+13	sinnel	simnel	NOUN	NN	Number=Sing|Typo=Yes	14	compound	14:compound	CorrectForm=simnel
 14	cake	cake	NOUN	NN	Number=Sing	12	obj	12:obj	_
 15	for	for	ADP	IN	_	16	case	16:case	_
 16	easter	Easter	PROPN	NNP	Number=Sing	14	nmod	14:nmod:for	_
@@ -165508,7 +165509,7 @@
 14	in	in	ADP	IN	_	17	case	17:case	_
 15	another	another	DET	DT	PronType=Ind	17	det	17:det	_
 16	blog	blog	NOUN	NN	Number=Sing	17	compound	17:compound	_
-17	entery	entery	NOUN	NN	Number=Sing	12	obl	12:obl:in	SpaceAfter=No
+17	entery	entry	NOUN	NN	Number=Sing|Typo=Yes	12	obl	12:obl:in	CorrectForm=entry|SpaceAfter=No
 18	.	.	PUNCT	.	_	7	punct	7:punct	_
 
 # sent_id = answers-20111108102810AAfCh1W_ans-0018
@@ -167559,7 +167560,7 @@
 6	trying	try	VERB	VBG	Tense=Pres|VerbForm=Part	0	root	0:root	_
 7	to	to	PART	TO	_	8	mark	8:mark	_
 8	melt	melt	VERB	VB	VerbForm=Inf	6	xcomp	6:xcomp	_
-9	bras	bras	NOUN	NN	Number=Sing	8	obj	8:obj	_
+9	bras	brass	NOUN	NN	Number=Sing|Typo=Yes	8	obj	8:obj	CorrectForm=brass
 10	to	to	PART	TO	_	11	mark	11:mark	_
 11	make	make	VERB	VB	VerbForm=Inf	8	advcl	8:advcl:to	_
 12	some	some	DET	DT	PronType=Ind	14	det	14:det	_
@@ -172752,7 +172753,7 @@
 1	what	what	PRON	WP	PronType=Int	0	root	0:root	Cxn=Interrogative-WHInfo-Direct|CxnElt=1:Interrogative-WHInfo-Direct.Clause,1:Interrogative-WHInfo-Direct.WHWord
 2	r	be	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|Typo=Yes|VerbForm=Fin	1	cop	1:cop	CorrectForm='re
 3	the	the	DET	DT	Definite=Def|PronType=Art	5	det	5:det	_
-4	evidentary	evidentary	ADJ	JJ	Degree=Pos	5	amod	5:amod	_
+4	evidentary	evidentiary	ADJ	JJ	Degree=Pos|Typo=Yes	5	amod	5:amod	CorrectForm=evidentiary
 5	requirements	requirement	NOUN	NNS	Number=Plur	1	nsubj	1:nsubj	_
 6	to	to	PART	TO	_	7	mark	7:mark	_
 7	apply	apply	VERB	VB	VerbForm=Inf	5	acl	5:acl:to	_
@@ -174065,7 +174066,7 @@
 4	1	1	NUM	CD	NumForm=Digit|NumType=Card	5	nummod	5:nummod	_
 5	year	year	NOUN	NN	Number=Sing	3	obj	3:obj	_
 6	before	before	ADP	IN	_	7	case	7:case	_
-7	collage	collage	NOUN	NN	Number=Sing	3	obl	3:obl:before	SpaceAfter=No
+7	collage	college	NOUN	NN	Number=Sing|Typo=Yes	3	obl	3:obl:before	CorrectForm=college|SpaceAfter=No
 8	!	!	PUNCT	.	_	3	punct	3:punct	SpaceAfter=No
 9	)	)	PUNCT	-RRB-	_	3	punct	3:punct	_
 
@@ -174591,9 +174592,9 @@
 1	1	1	NUM	CD	NumForm=Digit|NumType=Card	2	nummod	2:nummod	_
 2	year	year	NOUN	NN	Number=Sing	4	nmod:unmarked	4:nmod:unmarked	_
 3	before	before	ADP	IN	_	4	case	4:case	_
-4	collage	collage	NOUN	NN	Number=Sing	0	root	0:root	_
+4	collage	collage	NOUN	NN	Number=Sing	0	root	0:root	Mentioned=Yes
 5	or	or	CCONJ	CC	_	6	cc	6:cc	_
-6	college	college	NOUN	NN	Number=Sing	4	conj	4:conj:or	SpaceAfter=No
+6	college	college	NOUN	NN	Number=Sing	4	conj	4:conj:or	Mentioned=Yes|SpaceAfter=No
 7	?	?	PUNCT	.	_	4	punct	4:punct	_
 
 # sent_id = answers-20111108102445AA5mfrq_ans-0038
@@ -175708,7 +175709,7 @@
 34	and	and	CCONJ	CC	_	35	cc	35:cc	_
 35	lots	lot	NOUN	NNS	Number=Plur	18	conj	11:appos|18:conj:and	_
 36	of	of	ADP	IN	_	37	case	37:case	_
-37	repition	repition	NOUN	NN	Number=Sing	35	nmod	35:nmod:of	SpaceAfter=No
+37	repition	repetition	NOUN	NN	Number=Sing|Typo=Yes	35	nmod	35:nmod:of	CorrectForm=repetition|SpaceAfter=No
 38	....	....	PUNCT	,	_	39	punct	39:punct	SpaceAfter=No
 39	Right	right	INTJ	UH	_	11	discourse	11:discourse	SpaceAfter=No
 40	?	?	PUNCT	.	_	11	punct	11:punct	_
@@ -177147,7 +177148,7 @@
 12	one	one	NUM	CD	NumForm=Word|NumType=Card	11	obl:unmarked	11:obl:unmarked	_
 13	for	for	ADP	IN	_	15	case	15:case	_
 14	a	a	DET	DT	Definite=Ind|PronType=Art	15	det	15:det	_
-15	wile	wile	NOUN	NN	Number=Sing	11	obl	11:obl:for	SpaceAfter=No
+15	wile	while	NOUN	NN	Number=Sing|Typo=Yes	11	obl	11:obl:for	CorrectForm=while|SpaceAfter=No
 16	,	,	PUNCT	,	_	11	punct	11:punct	_
 17	then	then	ADV	RB	PronType=Dem	18	advmod	18:advmod	_
 18	up	up	ADV	RB	_	7	parataxis	5:xcomp|7:parataxis	_
@@ -177229,7 +177230,7 @@
 14	and	and	CCONJ	CC	_	15	cc	15:cc	_
 15	use	use	VERB	VB	VerbForm=Inf	6	conj	4:xcomp|6:conj:and	_
 16	your	your	PRON	PRP$	Case=Gen|Person=2|Poss=Yes|PronType=Prs	17	nmod:poss	17:nmod:poss	_
-17	wight	wight	NOUN	NN	Number=Sing	15	obj	15:obj	_
+17	wight	weight	NOUN	NN	Number=Sing|Typo=Yes	15	obj	15:obj	CorrectForm=weight
 18	correctly	correctly	ADV	RB	_	15	advmod	15:advmod	SpaceAfter=No
 19	,	,	PUNCT	,	_	21	punct	21:punct	_
 20	to	to	PART	TO	_	21	mark	21:mark	_
@@ -177401,7 +177402,7 @@
 1	maybe	maybe	ADV	RB	_	6	advmod	6:advmod	_
 2	a	a	DET	DT	Definite=Ind|PronType=Art	4	det	4:det	_
 3	back	back	NOUN	NN	Number=Sing	4	compound	4:compound	_
-4	brase	brase	NOUN	NN	Number=Sing	6	nsubj	6:nsubj	_
+4	brase	brace	NOUN	NN	Number=Sing|Typo=Yes	6	nsubj	6:nsubj	CorrectForm=brace
 5	will	will	AUX	MD	VerbForm=Fin	6	aux	6:aux	_
 6	help	help	VERB	VB	VerbForm=Inf	0	root	0:root	SpaceAfter=No
 7	,	,	PUNCT	,	_	12	punct	12:punct	_
@@ -177694,7 +177695,7 @@
 # text = I have tryed to give him water but he wont take it.. what should i do?
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	3	nsubj	3:nsubj|5:nsubj:xsubj	_
 2	have	have	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	3	aux	3:aux	_
-3	tryed	trye	VERB	VBN	Tense=Past|VerbForm=Part	0	root	0:root	_
+3	tryed	try	VERB	VBN	Tense=Past|Typo=Yes|VerbForm=Part	0	root	0:root	CorrectForm=tried
 4	to	to	PART	TO	_	5	mark	5:mark	_
 5	give	give	VERB	VB	VerbForm=Inf	3	xcomp	3:xcomp	_
 6	him	he	PRON	PRP	Case=Acc|Gender=Masc|Number=Sing|Person=3|PronType=Prs	5	iobj	5:iobj	_
@@ -177802,7 +177803,7 @@
 17	nt	not	PART	RB	Polarity=Neg|Typo=Yes	19	advmod	19:advmod	CorrectForm=n't
 18	be	be	AUX	VB	VerbForm=Inf	19	aux	19:aux	_
 19	buying	buy	VERB	VBG	Tense=Pres|VerbForm=Part	2	conj	2:conj:but	_
-20	grocerys	grocery	NOUN	NNS	Number=Plur	19	obj	19:obj	_
+20	grocerys	grocery	NOUN	NNS	Number=Plur|Typo=Yes	19	obj	19:obj	CorrectForm=groceries
 21	for	for	ADP	IN	_	25	case	25:case	_
 22	the	the	DET	DT	Definite=Def|PronType=Art	25	det	25:det	_
 23	next	next	ADJ	JJ	Degree=Pos	25	amod	25:amod	_
@@ -183088,7 +183089,7 @@
 27	important	important	ADJ	JJ	Degree=Pos	26	amod	26:amod	_
 28	to	to	ADP	IN	_	33	case	33:case	_
 29	the	the	DET	DT	Definite=Def|PronType=Art	33	det	33:det	_
-30	psycholical	psycholical	ADJ	JJ	Degree=Pos	33	amod	33:amod	_
+30	psycholical	psychological	ADJ	JJ	Degree=Pos|Typo=Yes	33	amod	33:amod	CorrectForm=psychological
 31	well	well	ADJ	JJ	Degree=Pos	33	amod	33:amod	SpaceAfter=No
 32	-	-	PUNCT	HYPH	_	31	punct	31:punct	SpaceAfter=No
 33	being	being	NOUN	NN	Number=Sing	27	obl	27:obl:to	_
@@ -183405,7 +183406,7 @@
 10-11	Zoomed's	_	_	_	_	_	_	_	_
 10	Zoomed	Zoomed	PROPN	NNP	Number=Sing	13	nmod:poss	13:nmod:poss	_
 11	's	's	PART	POS	_	10	case	10:case	_
-12	Repsitun	Repsitun	PROPN	NNP	Number=Sing	13	compound	13:compound	_
+12	Repsitun	ReptiSun	PROPN	NNP	Number=Sing|Typo=Yes	13	compound	13:compound	CorrectForm=ReptiSun
 13	model	model	NOUN	NN	Number=Sing	7	obl	7:obl:like	SpaceAfter=No
 14	:	:	PUNCT	:	_	15	punct	15:punct	_
 15	http://lllreptile.com/store/catalog/reptile-supplies/uvb-fluorescent-lights-mercury-vapor-bulbs/-/zoo-med-24-repti-sun-100-fluorescent-bulb/	http://lllreptile.com/store/catalog/reptile-supplies/uvb-fluorescent-lights-mercury-vapor-bulbs/-/zoo-med-24-repti-sun-100-fluorescent-bulb/	PROPN	ADD	_	13	appos	13:appos	_
@@ -184185,7 +184186,7 @@
 6	one	one	NUM	CD	NumForm=Word|NumType=Card	8	nsubj	8:nsubj	_
 7	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	8	cop	8:cop	_
 8	better	good	ADJ	JJR	Degree=Cmp	4	advcl	4:advcl	_
-9	thx	thx	NOUN	NN	Number=Sing	4	discourse	4:discourse	SpaceAfter=No
+9	thx	thanks	NOUN	NN	Abbr=Yes|Number=Sing	4	discourse	4:discourse	SpaceAfter=No
 10	!!!!!!	!!!!!!	PUNCT	.	_	9	punct	9:punct	_
 
 # sent_id = answers-20111108092643AAXe4lD_ans-0005
@@ -184591,7 +184592,7 @@
 5	hair	hair	NOUN	NN	Number=Sing	0	root	0:root	_
 6	the	the	DET	DT	Definite=Def|PronType=Art	8	det	8:det	_
 7	less	less	ADJ	JJR	Degree=Cmp	8	amod	8:amod	_
-8	stipes	stipe	NOUN	NNS	Number=Plur	10	advcl	10:advcl:the	_
+8	stipes	stripe	NOUN	NNS	Number=Plur|Typo=Yes	10	advcl	10:advcl:the	CorrectForm=stripes
 9	the	the	DET	DT	Definite=Def|PronType=Art	10	det	10:det	_
 10	older	old	ADJ	JJR	Degree=Cmp	5	parataxis	5:parataxis	SpaceAfter=No
 11	.	.	PUNCT	.	_	5	punct	5:punct	_
@@ -185152,7 +185153,7 @@
 21	jump	jump	VERB	VB	VerbForm=Inf	16	advcl	16:advcl:as	_
 22	back	back	ADV	RB	_	21	advmod	21:advmod	_
 23	or	or	CCONJ	CC	_	24	cc	24:cc	_
-24	screem	screem	VERB	VB	VerbForm=Inf	21	conj	16:advcl:as|21:conj:or	_
+24	screem	scream	VERB	VB	Typo=Yes|VerbForm=Inf	21	conj	16:advcl:as|21:conj:or	CorrectForm=scream
 25	they	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	27	nsubj	27:nsubj|28:nsubj:xsubj	_
 26	will	will	AUX	MD	VerbForm=Fin	27	aux	27:aux	_
 27	get	get	VERB	VB	VerbForm=Inf	9	conj	9:conj:but	_
@@ -185271,7 +185272,7 @@
 15	go	go	VERB	VB	VerbForm=Inf	13	xcomp	13:xcomp	_
 16	on	on	ADP	IN	_	18	case	18:case	_
 17	my	my	PRON	PRP$	Case=Gen|Number=Sing|Person=1|Poss=Yes|PronType=Prs	18	nmod:poss	18:nmod:poss	_
-18	sholder	sholder	NOUN	NN	Number=Sing	15	obl	15:obl:on	SpaceAfter=No
+18	sholder	shoulder	NOUN	NN	Number=Sing|Typo=Yes	15	obl	15:obl:on	CorrectForm=shoulder|SpaceAfter=No
 19	,	,	PUNCT	,	_	25	punct	25:punct	_
 20	when	when	ADV	WRB	PronType=Int	22	advmod	22:advmod	_
 21	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	22	nsubj	22:nsubj	_
@@ -186579,7 +186580,7 @@
 16	according	accord	VERB	VBG	ExtPos=ADP|Tense=Pres|VerbForm=Part	19	case	19:case	_
 17	to	to	ADP	IN	_	16	fixed	16:fixed	_
 18	the	the	DET	DT	Definite=Def|PronType=Art	19	det	19:det	_
-19	calender	calender	NOUN	NN	Number=Sing	15	obl	15:obl:according_to	SpaceAfter=No
+19	calender	calendar	NOUN	NN	Number=Sing|Typo=Yes	15	obl	15:obl:according_to	CorrectForm=calendar|SpaceAfter=No
 20	.	.	PUNCT	.	_	5	punct	5:punct	_
 
 # sent_id = answers-20111107175720AAlb2TB_ans-0042
@@ -187322,7 +187323,7 @@
 3	and	and	CCONJ	CC	_	4	cc	4:cc	_
 4	ammonia	ammonia	NOUN	NN	Number=Sing	2	conj	2:conj:and|10:nsubj	_
 5	(	(	PUNCT	-LRB-	_	6	punct	6:punct	SpaceAfter=No
-6	choramine	choramine	NOUN	NN	Number=Sing	2	appos	2:appos	SpaceAfter=No
+6	choramine	chloramine	NOUN	NN	Number=Sing|Typo=Yes	2	appos	2:appos	CorrectForm=chloramine|SpaceAfter=No
 7	)	)	PUNCT	-RRB-	_	6	punct	6:punct	_
 8	are	be	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	10	cop	10:cop	_
 9	not	not	PART	RB	Polarity=Neg	10	advmod	10:advmod	_
@@ -188544,7 +188545,7 @@
 1	There	there	PRON	EX	PronType=Dem	2	expl	2:expl	_
 2	are	be	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	Cxn=Existential-CopPred-ThereExpl
 3	other	other	ADJ	JJ	Degree=Pos	4	amod	4:amod	_
-4	amnesties	amnesty	NOUN	NNS	Number=Plur	2	nsubj	2:nsubj	CxnElt=2:Existential-CopPred-ThereExpl.Pivot
+4	amnesties	amenity	NOUN	NNS	Number=Plur|Typo=Yes	2	nsubj	2:nsubj	CorrectForm=amenities|CxnElt=2:Existential-CopPred-ThereExpl.Pivot
 5	also	also	ADV	RB	_	2	advmod	2:advmod	SpaceAfter=No
 6	.	.	PUNCT	.	_	2	punct	2:punct	_
 
@@ -190903,7 +190904,7 @@
 8	..	..	PUNCT	,	_	11	punct	11:punct	_
 9	but	but	CCONJ	CC	_	11	cc	11:cc	_
 10	i	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	11	nsubj	11:nsubj	_
-11	guss	guss	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	5	conj	5:conj:but	_
+11	guss	guess	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|Typo=Yes|VerbForm=Fin	5	conj	5:conj:but	CorrectForm=guess
 12	it	it	PRON	PRP	Case=Nom|Gender=Neut|Number=Sing|Person=3|PronType=Prs	15	nsubj	15:nsubj	_
 13	was	be	AUX	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	15	cop	15:cop	_
 14	his	his	PRON	PRP$	Case=Gen|Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	15	nmod:poss	15:nmod:poss	_
@@ -193518,7 +193519,7 @@
 2	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	3	nsubj	3:nsubj	_
 3	need	need	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	17	advcl	17:advcl:if	CxnElt=17:Conditional-UnspecifiedEpistemic-NoInversion.Protasis|Supersense=v.cognition
 4	a	a	DET	DT	Definite=Ind|PronType=Art	5	det	5:det	_
-5	cater	cater	NOUN	NN	Number=Sing	3	obj	3:obj|8:nsubj|10:nsubj	Supersense=n.GROUP
+5	cater	caterer	NOUN	NN	Number=Sing|Typo=Yes	3	obj	3:obj|8:nsubj|10:nsubj	CorrectForm=caterer|Supersense=n.GROUP
 6	that	that	PRON	WDT	PronType=Rel	8	nsubj	5:ref	_
 7	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	8	cop	8:cop	Supersense=v.stative
 8	affordable	affordable	ADJ	JJ	Degree=Pos	5	acl:relcl	5:acl:relcl	Cxn=rc-that-nsubj-pstrand
@@ -203713,8 +203714,8 @@
 11	the	the	DET	DT	Definite=Def|PronType=Art	12	det	12:det	_
 12	minute	minute	NOUN	NN	Number=Sing	23	obl:unmarked	14:obl|23:obl:unmarked	Supersense=n.TIME|TemporalNPAdjunct=Yes
 13	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	14	nsubj	14:nsubj	_
-14	steep	steep	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	12	acl:relcl	12:acl:relcl	Cxn=rc-red-obl|Supersense=v.motion
-15	into	into	ADP	IN	_	17	case	17:case	PRel[config]=default|PRel[gov]=14:steep|PRel[obj]=17:school|Supersense=p.Goal
+14	steep	step	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|Typo=Yes|VerbForm=Fin	12	acl:relcl	12:acl:relcl	CorrectForm=step|Cxn=rc-red-obl|Supersense=v.motion
+15	into	into	ADP	IN	_	17	case	17:case	PRel[config]=default|PRel[gov]=14:step|PRel[obj]=17:school|Supersense=p.Goal
 16	their	their	PRON	PRP$	Case=Gen|Number=Plur|Person=3|Poss=Yes|PronType=Prs	17	nmod:poss	17:nmod:poss	PRel[config]=possessive|PRel[gov]=17:school|Supersense[coding]=p.Possessor|Supersense[scene]=p.OrgMember
 17	school	school	NOUN	NN	Number=Sing	14	obl	14:obl:into	SpaceAfter=No|Supersense=n.LOCATION
 18	,	,	PUNCT	,	_	12	punct	12:punct	_
@@ -233097,7 +233098,7 @@
 4	out	out	ADP	RP	_	3	compound:prt	3:compound:prt	PRel[config]=default|PRel[gov]=3:move|Supersense=p.Direction
 5	from	from	ADP	IN	_	8	case	8:case	PRel[config]=default|PRel[gov]=3:move|PRel[obj]=8:apartment|Supersense=p.Source
 6	2	2	NUM	CD	NumForm=Digit|NumType=Card	7	nummod	7:nummod	_
-7	bdr	bdr	NOUN	NN	Number=Sing	8	compound	8:compound	Supersense=n.ARTIFACT
+7	bdr	bedroom	NOUN	NN	Abbr=Yes|Number=Sing	8	compound	8:compound	Supersense=n.ARTIFACT
 8	apartment	apartment	NOUN	NN	Number=Sing	3	obl	3:obl:from	Supersense=n.ARTIFACT
 9	and	and	CCONJ	CC	_	11	cc	11:cc	_
 10	it	it	PRON	PRP	Case=Nom|Gender=Neut|Number=Sing|Person=3|PronType=Prs	11	nsubj	11:nsubj	_

--- a/not-to-release/sources/answers/20111106155648AAvG7DN_ans.xml.conllu
+++ b/not-to-release/sources/answers/20111106155648AAvG7DN_ans.xml.conllu
@@ -39,7 +39,7 @@
 24	sector	sector	NOUN	NN	Number=Sing	19	obl	19:obl:in	_
 25	as	as	ADP	IN	_	27	case	27:case	_
 26	your	your	PRON	PRP$	Case=Gen|Person=2|Poss=Yes|PronType=Prs	27	nmod:poss	27:nmod:poss	_
-27	skills	skill	NOUN	NNS	Number=Plur	24	nmod	24:nmod:as	_
+27	skills	skill	NOUN	NNS	Number=Plur	23	obl	23:obl:as	_
 28	on	on	ADP	IN	_	30	case	30:case	_
 29	your	your	PRON	PRP$	Case=Gen|Person=2|Poss=Yes|PronType=Prs	30	nmod:poss	30:nmod:poss	_
 30	application	application	NOUN	NN	Number=Sing	27	nmod	27:nmod:on	_

--- a/not-to-release/sources/answers/20111107144339AA0qw5S_ans.xml.conllu
+++ b/not-to-release/sources/answers/20111107144339AA0qw5S_ans.xml.conllu
@@ -105,7 +105,7 @@
 13	respects	respects	NOUN	NNS	Number=Ptan	11	obj	11:obj	_
 14	to	to	ADP	IN	_	16	case	16:case	_
 15	the	the	DET	DT	Definite=Def|PronType=Art	16	det	16:det	_
-16	desisted	desisted	ADJ	JJ	Degree=Pos	11	obl	11:obl:to	_
+16	desisted	deceased	ADJ	JJ	Degree=Pos|Typo=Yes	11	obl	11:obl:to	CorrectForm=deceased
 17	and	and	CCONJ	CC	_	19	cc	19:cc	_
 18	their	their	PRON	PRP$	Case=Gen|Number=Plur|Person=3|Poss=Yes|PronType=Prs	19	nmod:poss	19:nmod:poss	_
 19	family	family	NOUN	NN	Number=Sing	16	conj	11:obl:to|16:conj:and	_
@@ -298,7 +298,7 @@
 10	and	and	CCONJ	CC	_	19	cc	19:cc	_
 11	at	at	ADP	IN	_	13	case	13:case	_
 12	the	the	DET	DT	Definite=Def|PronType=Art	13	det	13:det	_
-13	hight	hight	NOUN	NN	Number=Sing	19	obl	19:obl:at	_
+13	hight	height	NOUN	NN	Number=Sing|Typo=Yes	19	obl	19:obl:at	CorrectForm=height
 14	of	of	ADP	IN	_	17	case	17:case	_
 15	the	the	DET	DT	Definite=Def|PronType=Art	17	det	17:det	_
 16	organization	organization	NOUN	NN	Number=Sing	17	compound	17:compound	_
@@ -432,7 +432,7 @@
 10	;	;	PUNCT	,	_	9	punct	9:punct	_
 11	we	we	PRON	PRP	Case=Nom|Number=Plur|Person=1|PronType=Prs	12	nsubj	12:nsubj	_
 12	make	make	VERB	VBP	Mood=Ind|Number=Plur|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	_
-13	sinnel	sinnel	NOUN	NN	Number=Sing	14	compound	14:compound	_
+13	sinnel	simnel	NOUN	NN	Number=Sing|Typo=Yes	14	compound	14:compound	CorrectForm=simnel
 14	cake	cake	NOUN	NN	Number=Sing	12	obj	12:obj	_
 15	for	for	ADP	IN	_	16	case	16:case	_
 16	easter	Easter	PROPN	NNP	Number=Sing	14	nmod	14:nmod:for	_

--- a/not-to-release/sources/answers/20111107173224AA22AwU_ans.xml.conllu
+++ b/not-to-release/sources/answers/20111107173224AA22AwU_ans.xml.conllu
@@ -82,11 +82,11 @@
 
 # sent_id = answers-20111107173224AA22AwU_ans-0007
 # text = just in the water?
-1	just	just	ADV	RB	_	0	root	0:root	_
+1	just	just	ADV	RB	_	4	advmod	4:advmod	_
 2	in	in	ADP	IN	_	4	case	4:case	_
 3	the	the	DET	DT	Definite=Def|PronType=Art	4	det	4:det	_
-4	water	water	NOUN	NN	Number=Sing	1	obl	1:obl:in	SpaceAfter=No
-5	?	?	PUNCT	.	_	1	punct	1:punct	_
+4	water	water	NOUN	NN	Number=Sing	0	root	0:root	SpaceAfter=No
+5	?	?	PUNCT	.	_	4	punct	4:punct	_
 
 # sent_id = answers-20111107173224AA22AwU_ans-0008
 # newpar id = answers-20111107173224AA22AwU_ans-p0005

--- a/not-to-release/sources/answers/20111107175720AAlb2TB_ans.xml.conllu
+++ b/not-to-release/sources/answers/20111107175720AAlb2TB_ans.xml.conllu
@@ -1158,7 +1158,7 @@
 16	according	accord	VERB	VBG	ExtPos=ADP|Tense=Pres|VerbForm=Part	19	case	19:case	_
 17	to	to	ADP	IN	_	16	fixed	16:fixed	_
 18	the	the	DET	DT	Definite=Def|PronType=Art	19	det	19:det	_
-19	calender	calender	NOUN	NN	Number=Sing	15	obl	15:obl:according_to	SpaceAfter=No
+19	calender	calendar	NOUN	NN	Number=Sing|Typo=Yes	15	obl	15:obl:according_to	CorrectForm=calendar|SpaceAfter=No
 20	.	.	PUNCT	.	_	5	punct	5:punct	_
 
 # sent_id = answers-20111107175720AAlb2TB_ans-0042

--- a/not-to-release/sources/answers/20111107193044AAvUYBv_ans.xml.conllu
+++ b/not-to-release/sources/answers/20111107193044AAvUYBv_ans.xml.conllu
@@ -73,7 +73,7 @@
 17	)	)	PUNCT	-RRB-	_	4	punct	4:punct	_
 18	so	so	ADV	RB	_	21	advmod	21:advmod	_
 19	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	21	nsubj	21:nsubj	_
-20	fineally	fineally	ADV	RB	_	21	advmod	21:advmod	_
+20	fineally	finally	ADV	RB	Typo=Yes	21	advmod	21:advmod	CorrectForm=finally
 21	checked	check	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	4	parataxis	4:parataxis	_
 22	it	it	PRON	PRP	Case=Acc|Gender=Neut|Number=Sing|Person=3|PronType=Prs	21	obj	21:obj	SpaceAfter=No
 23	,	,	PUNCT	,	_	28	punct	28:punct	_

--- a/not-to-release/sources/answers/20111107200249AAIyCy5_ans.xml.conllu
+++ b/not-to-release/sources/answers/20111107200249AAIyCy5_ans.xml.conllu
@@ -150,7 +150,7 @@
 20	subject	subject	NOUN	NN	Number=Sing	14	nmod	14:nmod:on	_
 21	as	as	ADP	IN	_	23	case	23:case	_
 22	another	another	DET	DT	PronType=Ind	23	det	23:det	_
-23	artist	artist	NOUN	NN	Number=Sing	20	nmod	20:nmod:as	_
+23	artist	artist	NOUN	NN	Number=Sing	19	obl	19:obl:as	_
 24	-	-	PUNCT	,	_	26	punct	26:punct	_
 25	clearly	clearly	ADV	RB	_	26	advmod	26:advmod	_
 26	insulting	insulting	ADJ	JJ	Degree=Pos	12	advcl	12:advcl	_

--- a/not-to-release/sources/answers/20111107212131AACQ65F_ans.xml.conllu
+++ b/not-to-release/sources/answers/20111107212131AACQ65F_ans.xml.conllu
@@ -49,7 +49,7 @@
 9	leave	leave	VERB	VB	VerbForm=Inf	7	xcomp	7:xcomp	_
 10	this	this	DET	DT	Number=Sing|PronType=Dem	12	det	12:det	_
 11	whole	whole	ADJ	JJ	Degree=Pos	12	amod	12:amod	_
-12	enviroment	enviroment	NOUN	NN	Number=Sing	9	obj	9:obj	SpaceAfter=No
+12	enviroment	environment	NOUN	NN	Number=Sing|Typo=Yes	9	obj	9:obj	CorrectForm=environment|SpaceAfter=No
 13	.	.	PUNCT	.	_	2	punct	2:punct	_
 
 # sent_id = answers-20111107212131AACQ65F_ans-0005

--- a/not-to-release/sources/answers/20111108051456AAQJaXR_ans.xml.conllu
+++ b/not-to-release/sources/answers/20111108051456AAQJaXR_ans.xml.conllu
@@ -20,7 +20,7 @@
 6	trying	try	VERB	VBG	Tense=Pres|VerbForm=Part	0	root	0:root	_
 7	to	to	PART	TO	_	8	mark	8:mark	_
 8	melt	melt	VERB	VB	VerbForm=Inf	6	xcomp	6:xcomp	_
-9	bras	bras	NOUN	NN	Number=Sing	8	obj	8:obj	_
+9	bras	brass	NOUN	NN	Number=Sing|Typo=Yes	8	obj	8:obj	CorrectForm=brass
 10	to	to	PART	TO	_	11	mark	11:mark	_
 11	make	make	VERB	VB	VerbForm=Inf	8	advcl	8:advcl:to	_
 12	some	some	DET	DT	PronType=Ind	14	det	14:det	_

--- a/not-to-release/sources/answers/20111108065616AAKtL2c_ans.xml.conllu
+++ b/not-to-release/sources/answers/20111108065616AAKtL2c_ans.xml.conllu
@@ -557,7 +557,7 @@
 1	There	there	PRON	EX	PronType=Dem	2	expl	2:expl	_
 2	are	be	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	Cxn=Existential-CopPred-ThereExpl
 3	other	other	ADJ	JJ	Degree=Pos	4	amod	4:amod	_
-4	amnesties	amnesty	NOUN	NNS	Number=Plur	2	nsubj	2:nsubj	CxnElt=2:Existential-CopPred-ThereExpl.Pivot
+4	amnesties	amenity	NOUN	NNS	Number=Plur|Typo=Yes	2	nsubj	2:nsubj	CorrectForm=amenities|CxnElt=2:Existential-CopPred-ThereExpl.Pivot
 5	also	also	ADV	RB	_	2	advmod	2:advmod	SpaceAfter=No
 6	.	.	PUNCT	.	_	2	punct	2:punct	_
 

--- a/not-to-release/sources/answers/20111108065707AAj7DaH_ans.xml.conllu
+++ b/not-to-release/sources/answers/20111108065707AAj7DaH_ans.xml.conllu
@@ -296,7 +296,7 @@
 48	,	,	PUNCT	,	_	49	punct	49:punct	_
 49	paper	paper	NOUN	NN	Number=Sing	36	conj	36:conj	SpaceAfter=No
 50	,	,	PUNCT	,	_	52	punct	52:punct	_
-51	bryer	bryer	NOUN	NN	Number=Sing	52	compound	52:compound	_
+51	bryer	Breyer	NOUN	NN	Number=Sing|Typo=Yes	52	compound	52:compound	CorrectForm=Breyer
 52	horses	horse	NOUN	NNS	Number=Plur	36	conj	36:conj	_
 
 # sent_id = answers-20111108065707AAj7DaH_ans-0015

--- a/not-to-release/sources/answers/20111108073410AAlpgTl_ans.xml.conllu
+++ b/not-to-release/sources/answers/20111108073410AAlpgTl_ans.xml.conllu
@@ -20,7 +20,7 @@
 
 # sent_id = answers-20111108073410AAlpgTl_ans-0002
 # text = thx for your ans.?
-1	thx	thx	NOUN	NN	Number=Sing	0	root	0:root	_
+1	thx	thanks	NOUN	NN	Abbr=Yes|Number=Sing	0	root	0:root	_
 2	for	for	ADP	IN	_	4	case	4:case	_
 3	your	your	PRON	PRP$	Case=Gen|Person=2|Poss=Yes|PronType=Prs	4	nmod:poss	4:nmod:poss	_
 4	ans	ans	NOUN	NN	Number=Sing	1	nmod	1:nmod:for	SpaceAfter=No

--- a/not-to-release/sources/answers/20111108080100AAJHNUK_ans.xml.conllu
+++ b/not-to-release/sources/answers/20111108080100AAJHNUK_ans.xml.conllu
@@ -76,7 +76,7 @@
 6	please	please	INTJ	UH	_	7	discourse	7:discourse	_
 7	list	list	VERB	VB	Mood=Imp|VerbForm=Fin	0	root	0:root	_
 8	:)	:)	SYM	NFP	_	9	discourse	9:discourse	_
-9	Thx	thx	NOUN	NN	Number=Sing	7	discourse	7:discourse	_
+9	Thx	thanks	NOUN	NN	Abbr=Yes|Number=Sing	7	discourse	7:discourse	_
 
 # sent_id = answers-20111108080100AAJHNUK_ans-0007
 # newpar id = answers-20111108080100AAJHNUK_ans-p0003
@@ -157,7 +157,7 @@
 11	make	make	VERB	VB	VerbForm=Inf	1	parataxis	1:parataxis	_
 12	your	your	PRON	PRP$	Case=Gen|Person=2|Poss=Yes|PronType=Prs	13	nmod:poss	13:nmod:poss	_
 13	image	image	NOUN	NN	Number=Sing	11	obj	11:obj|14:nsubj:xsubj|16:nsubj:xsubj	_
-14	blak	blak	ADJ	JJ	Degree=Pos	11	xcomp	11:xcomp	_
+14	blak	black	ADJ	JJ	Degree=Pos|Typo=Yes	11	xcomp	11:xcomp	CorrectForm=black
 15	and	and	CCONJ	CC	_	16	cc	16:cc	_
 16	white	white	ADJ	JJ	Degree=Pos	14	conj	11:xcomp|14:conj:and	SpaceAfter=No
 17	.	.	PUNCT	.	_	1	punct	1:punct	_

--- a/not-to-release/sources/answers/20111108082505AAtbdh9_ans.xml.conllu
+++ b/not-to-release/sources/answers/20111108082505AAtbdh9_ans.xml.conllu
@@ -262,7 +262,7 @@
 # newpar id = answers-20111108082505AAtbdh9_ans-p0005
 # text = hey kido u made me smile
 1	hey	hey	INTJ	UH	_	2	discourse	2:discourse	_
-2	kido	kido	NOUN	NN	Number=Sing	4	vocative	4:vocative	_
+2	kido	kiddo	NOUN	NN	Number=Sing|Typo=Yes	4	vocative	4:vocative	CorrectForm=kiddo
 3	u	you	PRON	PRP	Abbr=Yes|Case=Nom|Person=2|PronType=Prs	4	nsubj	4:nsubj	CorrectForm=you
 4	made	make	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	0:root	_
 5	me	I	PRON	PRP	Case=Acc|Number=Sing|Person=1|PronType=Prs	4	obj	4:obj|6:nsubj:xsubj	_

--- a/not-to-release/sources/answers/20111108084111AAl5ras_ans.xml.conllu
+++ b/not-to-release/sources/answers/20111108084111AAl5ras_ans.xml.conllu
@@ -68,7 +68,7 @@
 1	Why	why	ADV	WRB	PronType=Int	5	advmod	5:advmod	CxnElt=5:Interrogative-WHInfo-Direct.WHWord
 2	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	5	aux	5:aux	_
 3	it	it	PRON	PRP	Case=Nom|Gender=Neut|Number=Sing|Person=3|PronType=Prs	5	nsubj	5:nsubj	_
-4	stil	stil	ADV	RB	_	5	advmod	5:advmod	_
+4	stil	still	ADV	RB	Typo=Yes	5	advmod	5:advmod	CorrectForm=still
 5	doing	do	VERB	VBG	Tense=Pres|VerbForm=Part	0	root	0:root	Cxn=Interrogative-WHInfo-Direct|CxnElt=5:Interrogative-WHInfo-Direct.Clause
 6	this	this	PRON	DT	Number=Sing|PronType=Dem	5	obj	5:obj	_
 7	even	even	ADV	RB	_	12	advmod	12:advmod	_

--- a/not-to-release/sources/answers/20111108084119AAhsBk8_ans.xml.conllu
+++ b/not-to-release/sources/answers/20111108084119AAhsBk8_ans.xml.conllu
@@ -55,8 +55,8 @@
 8	newest	new	ADJ	JJS	Degree=Sup	9	amod	9:amod	_
 9	version	version	NOUN	NN	Number=Sing	6	obj	6:obj	_
 10	of	of	ADP	IN	_	12	case	12:case	_
-11	Cyanogen	cyanogen	PROPN	NNP	Number=Sing	12	compound	12:compound	_
-12	Mod	mod	PROPN	NNP	Number=Sing	9	nmod	9:nmod:of	SpaceAfter=No
+11	Cyanogen	Cyanogen	PROPN	NNP	Number=Sing	12	compound	12:compound	_
+12	Mod	Mod	PROPN	NNP	Number=Sing	9	nmod	9:nmod:of	SpaceAfter=No
 13	.	.	PUNCT	.	_	6	punct	6:punct	_
 
 # sent_id = answers-20111108084119AAhsBk8_ans-0005
@@ -103,7 +103,7 @@
 # sent_id = answers-20111108084119AAhsBk8_ans-0007
 # newpar id = answers-20111108084119AAhsBk8_ans-p0004
 # text = cynangon mod should work.
-1	cynangon	Cynangon	PROPN	NNP	Number=Sing	2	compound	2:compound	_
+1	cynangon	Cyanogen	PROPN	NNP	Number=Sing|Typo=Yes	2	compound	2:compound	CorrectForm=Cyanogen
 2	mod	Mod	PROPN	NNP	Number=Sing	4	nsubj	4:nsubj	_
 3	should	should	AUX	MD	VerbForm=Fin	4	aux	4:aux	_
 4	work	work	VERB	VB	VerbForm=Inf	0	root	0:root	SpaceAfter=No

--- a/not-to-release/sources/answers/20111108084416AAoPgBv_ans.xml.conllu
+++ b/not-to-release/sources/answers/20111108084416AAoPgBv_ans.xml.conllu
@@ -435,7 +435,7 @@
 14	the	the	DET	DT	Definite=Def|PronType=Art	17	det	17:det	_
 15	most	most	ADV	RBS	Degree=Sup	16	advmod	16:advmod	_
 16	amazing	amazing	ADJ	JJ	Degree=Pos	17	amod	17:amod	_
-17	experice	experice	NOUN	NN	Number=Sing	2	conj	2:conj:and	_
+17	experice	experience	NOUN	NN	Number=Sing|Typo=Yes	2	conj	2:conj:and	CorrectForm=experience
 18	of	of	ADP	IN	_	20	case	20:case	_
 19	my	my	PRON	PRP$	Case=Gen|Number=Sing|Person=1|Poss=Yes|PronType=Prs	20	nmod:poss	20:nmod:poss	_
 20	upbringing	upbringing	NOUN	NN	Number=Sing	17	nmod	17:nmod:of	SpaceAfter=No

--- a/not-to-release/sources/answers/20111108084633AAzZD8i_ans.xml.conllu
+++ b/not-to-release/sources/answers/20111108084633AAzZD8i_ans.xml.conllu
@@ -55,5 +55,5 @@
 # text = like 2day
 1	like	like	INTJ	UH	_	3	discourse	3:discourse	_
 2	2	2	NUM	CD	NumForm=Digit|NumType=Card	3	nummod	3:nummod	SpaceAfter=No
-3	day	day	NOUN	NN	Number=Sing	0	root	0:root	_
+3	day	day	NOUN	NN	Number=Sing|Typo=Yes	0	root	0:root	CorrectForm=days|CorrectNumber=Plur
 

--- a/not-to-release/sources/answers/20111108090913AAf83Jh_ans.xml.conllu
+++ b/not-to-release/sources/answers/20111108090913AAf83Jh_ans.xml.conllu
@@ -7,7 +7,7 @@
 3	possible	possible	ADJ	JJ	Degree=Pos	0	root	0:root	_
 4	to	to	PART	TO	_	5	mark	5:mark	_
 5	shoot	shoot	VERB	VB	VerbForm=Inf	3	csubj	3:csubj	_
-6	lazers	lazer	NOUN	NNS	Number=Plur	5	obj	5:obj	_
+6	lazers	laser	NOUN	NNS	Number=Plur|Typo=Yes	5	obj	5:obj	CorrectForm=lasers
 7	out	out	ADP	IN	_	10	case	10:case	_
 8	of	of	ADP	IN	_	10	case	10:case	_
 9	your	your	PRON	PRP$	Case=Gen|Person=2|Poss=Yes|PronType=Prs	10	nmod:poss	10:nmod:poss	_

--- a/not-to-release/sources/answers/20111108091921AAaLK4e_ans.xml.conllu
+++ b/not-to-release/sources/answers/20111108091921AAaLK4e_ans.xml.conllu
@@ -1493,7 +1493,7 @@
 8	..	..	PUNCT	,	_	11	punct	11:punct	_
 9	but	but	CCONJ	CC	_	11	cc	11:cc	_
 10	i	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	11	nsubj	11:nsubj	_
-11	guss	guss	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	5	conj	5:conj:but	_
+11	guss	guess	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|Typo=Yes|VerbForm=Fin	5	conj	5:conj:but	CorrectForm=guess
 12	it	it	PRON	PRP	Case=Nom|Gender=Neut|Number=Sing|Person=3|PronType=Prs	15	nsubj	15:nsubj	_
 13	was	be	AUX	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	15	cop	15:cop	_
 14	his	his	PRON	PRP$	Case=Gen|Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	15	nmod:poss	15:nmod:poss	_

--- a/not-to-release/sources/answers/20111108092029AAsHTYP_ans.xml.conllu
+++ b/not-to-release/sources/answers/20111108092029AAsHTYP_ans.xml.conllu
@@ -219,7 +219,7 @@
 9	,	,	PUNCT	,	_	12	punct	12:punct	_
 10	which	which	PRON	WDT	PronType=Rel	12	nsubj	8:ref	_
 11	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	12	cop	12:cop	_
-12	dominate	dominate	ADJ	JJ	Degree=Pos	8	acl:relcl	8:acl:relcl	Cxn=rc-wh-nsubj|SpaceAfter=No
+12	dominate	dominant	ADJ	JJ	Degree=Pos|Typo=Yes	8	acl:relcl	8:acl:relcl	CorrectForm=dominant|Cxn=rc-wh-nsubj|SpaceAfter=No
 13	.	.	PUNCT	.	_	2	punct	2:punct	_
 
 # sent_id = answers-20111108092029AAsHTYP_ans-0013
@@ -233,7 +233,7 @@
 7	be	be	AUX	VB	VerbForm=Inf	8	cop	8:cop	_
 8	recessive	recessive	ADJ	JJ	Degree=Pos	4	acl:relcl	4:acl:relcl	Cxn=rc-wh-nsubj
 9	or	or	CCONJ	CC	_	10	cc	10:cc	_
-10	dominate	dominate	ADJ	JJ	Degree=Pos	8	conj	4:acl:relcl|8:conj:or	SpaceAfter=No
+10	dominate	dominant	ADJ	JJ	Degree=Pos|Typo=Yes	8	conj	4:acl:relcl|8:conj:or	CorrectForm=dominant|SpaceAfter=No
 11	.	.	PUNCT	.	_	2	punct	2:punct	_
 
 # sent_id = answers-20111108092029AAsHTYP_ans-0014
@@ -292,7 +292,7 @@
 24	genes	gene	NOUN	NNS	Number=Plur	27	nsubj	27:nsubj	_
 25	are	be	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	27	cop	27:cop	_
 26	incomplete	incomplete	ADV	RB	_	27	advmod	27:advmod	_
-27	dominate	dominate	ADJ	JJ	Degree=Pos	16	advcl	16:advcl:as	SpaceAfter=No
+27	dominate	dominant	ADJ	JJ	Degree=Pos|Typo=Yes	16	advcl	16:advcl:as	CorrectForm=dominant|SpaceAfter=No
 28	.	.	PUNCT	.	_	3	punct	3:punct	_
 
 # sent_id = answers-20111108092029AAsHTYP_ans-0017
@@ -314,7 +314,7 @@
 15	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	18	cop	18:cop	_
 16	also	also	ADV	RB	_	18	advmod	18:advmod	_
 17	incomplete	incomplete	ADV	RB	_	18	advmod	18:advmod	_
-18	dominate	dominate	ADJ	JJ	Degree=Pos	8	advcl	8:advcl:as	SpaceAfter=No
+18	dominate	dominant	ADJ	JJ	Degree=Pos|Typo=Yes	8	advcl	8:advcl:as	CorrectForm=dominant|SpaceAfter=No
 19	.	.	PUNCT	.	_	2	punct	2:punct	_
 
 # sent_id = answers-20111108092029AAsHTYP_ans-0018
@@ -334,7 +334,7 @@
 13	being	be	AUX	VBG	Tense=Pres|VerbForm=Part	17	cop	17:cop	_
 14	another	another	DET	DT	PronType=Ind	17	det	17:det	_
 15	incomplete	incomplete	ADV	RB	_	17	advmod	17:advmod	_
-16	dominate	dominate	ADJ	JJ	Degree=Pos	17	amod	17:amod	_
+16	dominate	dominant	ADJ	JJ	Degree=Pos|Typo=Yes	17	amod	17:amod	CorrectForm=dominant
 17	gene	gene	NOUN	NN	Number=Sing	6	advcl	6:advcl:due_to	SpaceAfter=No
 18	.	.	PUNCT	.	_	1	punct	1:punct	_
 
@@ -420,7 +420,7 @@
 5	toes	toe	NOUN	NNS	Number=Plur	8	nsubj	8:nsubj	_
 6	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	8	cop	8:cop	_
 7	incompletely	incompletely	ADV	RB	_	8	advmod	8:advmod	_
-8	dominate	dominate	ADJ	JJ	Degree=Pos	12	parataxis	12:parataxis	SpaceAfter=No
+8	dominate	dominant	ADJ	JJ	Degree=Pos|Typo=Yes	12	parataxis	12:parataxis	CorrectForm=dominant|SpaceAfter=No
 9	)	)	PUNCT	-RRB-	_	8	punct	8:punct	_
 10	chicks	chick	NOUN	NNS	Number=Plur	12	nsubj	12:nsubj	_
 11	could	could	AUX	MD	VerbForm=Fin	12	aux	12:aux	_

--- a/not-to-release/sources/answers/20111108092321AAK0Eqp_ans.xml.conllu
+++ b/not-to-release/sources/answers/20111108092321AAK0Eqp_ans.xml.conllu
@@ -23,7 +23,7 @@
 1	what	what	PRON	WP	PronType=Int	0	root	0:root	Cxn=Interrogative-WHInfo-Direct|CxnElt=1:Interrogative-WHInfo-Direct.Clause,1:Interrogative-WHInfo-Direct.WHWord
 2	r	be	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|Typo=Yes|VerbForm=Fin	1	cop	1:cop	CorrectForm='re
 3	the	the	DET	DT	Definite=Def|PronType=Art	5	det	5:det	_
-4	evidentary	evidentary	ADJ	JJ	Degree=Pos	5	amod	5:amod	_
+4	evidentary	evidentiary	ADJ	JJ	Degree=Pos|Typo=Yes	5	amod	5:amod	CorrectForm=evidentiary
 5	requirements	requirement	NOUN	NNS	Number=Plur	1	nsubj	1:nsubj	_
 6	to	to	PART	TO	_	7	mark	7:mark	_
 7	apply	apply	VERB	VB	VerbForm=Inf	5	acl	5:acl:to	_

--- a/not-to-release/sources/answers/20111108092643AAXe4lD_ans.xml.conllu
+++ b/not-to-release/sources/answers/20111108092643AAXe4lD_ans.xml.conllu
@@ -100,7 +100,7 @@
 6	one	one	NUM	CD	NumForm=Word|NumType=Card	8	nsubj	8:nsubj	_
 7	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	8	cop	8:cop	_
 8	better	good	ADJ	JJR	Degree=Cmp	4	advcl	4:advcl	_
-9	thx	thx	NOUN	NN	Number=Sing	4	discourse	4:discourse	SpaceAfter=No
+9	thx	thanks	NOUN	NN	Abbr=Yes|Number=Sing	4	discourse	4:discourse	SpaceAfter=No
 10	!!!!!!	!!!!!!	PUNCT	.	_	9	punct	9:punct	_
 
 # sent_id = answers-20111108092643AAXe4lD_ans-0005
@@ -506,7 +506,7 @@
 5	hair	hair	NOUN	NN	Number=Sing	0	root	0:root	_
 6	the	the	DET	DT	Definite=Def|PronType=Art	8	det	8:det	_
 7	less	less	ADJ	JJR	Degree=Cmp	8	amod	8:amod	_
-8	stipes	stipe	NOUN	NNS	Number=Plur	10	advcl	10:advcl:the	_
+8	stipes	stripe	NOUN	NNS	Number=Plur|Typo=Yes	10	advcl	10:advcl:the	CorrectForm=stripes
 9	the	the	DET	DT	Definite=Def|PronType=Art	10	det	10:det	_
 10	older	old	ADJ	JJR	Degree=Cmp	5	parataxis	5:parataxis	SpaceAfter=No
 11	.	.	PUNCT	.	_	5	punct	5:punct	_
@@ -1067,7 +1067,7 @@
 21	jump	jump	VERB	VB	VerbForm=Inf	16	advcl	16:advcl:as	_
 22	back	back	ADV	RB	_	21	advmod	21:advmod	_
 23	or	or	CCONJ	CC	_	24	cc	24:cc	_
-24	screem	screem	VERB	VB	VerbForm=Inf	21	conj	16:advcl:as|21:conj:or	_
+24	screem	scream	VERB	VB	Typo=Yes|VerbForm=Inf	21	conj	16:advcl:as|21:conj:or	CorrectForm=scream
 25	they	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	27	nsubj	27:nsubj|28:nsubj:xsubj	_
 26	will	will	AUX	MD	VerbForm=Fin	27	aux	27:aux	_
 27	get	get	VERB	VB	VerbForm=Inf	9	conj	9:conj:but	_
@@ -1186,7 +1186,7 @@
 15	go	go	VERB	VB	VerbForm=Inf	13	xcomp	13:xcomp	_
 16	on	on	ADP	IN	_	18	case	18:case	_
 17	my	my	PRON	PRP$	Case=Gen|Number=Sing|Person=1|Poss=Yes|PronType=Prs	18	nmod:poss	18:nmod:poss	_
-18	sholder	sholder	NOUN	NN	Number=Sing	15	obl	15:obl:on	SpaceAfter=No
+18	sholder	shoulder	NOUN	NN	Number=Sing|Typo=Yes	15	obl	15:obl:on	CorrectForm=shoulder|SpaceAfter=No
 19	,	,	PUNCT	,	_	25	punct	25:punct	_
 20	when	when	ADV	WRB	PronType=Int	22	advmod	22:advmod	_
 21	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	22	nsubj	22:nsubj	_

--- a/not-to-release/sources/answers/20111108094504AAKrc8F_ans.xml.conllu
+++ b/not-to-release/sources/answers/20111108094504AAKrc8F_ans.xml.conllu
@@ -66,7 +66,7 @@
 4	to	to	PART	TO	_	5	mark	5:mark	_
 5	go	go	VERB	VB	VerbForm=Inf	3	csubj	3:csubj	_
 6	to	to	ADP	IN	_	7	case	7:case	_
-7	Rotarua	Rotarua	PROPN	NNP	Number=Sing	5	obl	5:obl:to	SpaceAfter=No
+7	Rotarua	Rotorua	PROPN	NNP	Number=Sing|Typo=Yes	5	obl	5:obl:to	CorrectForm=Rotorua|SpaceAfter=No
 8	,	,	PUNCT	,	_	11	punct	11:punct	_
 9	since	since	ADP	IN	_	11	case	11:case	_
 10	the	the	DET	DT	Definite=Def|PronType=Art	11	det	11:det	_
@@ -109,7 +109,7 @@
 22	so	so	ADV	RB	_	25	advmod	25:advmod	_
 23	nothing	nothing	PRON	NN	Number=Sing|PronType=Neg	25	nsubj:pass	25:nsubj:pass	_
 24	was	be	AUX	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	25	aux:pass	25:aux:pass	_
-25	effected	effect	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	15	parataxis	15:parataxis	_
+25	effected	affect	VERB	VBN	Tense=Past|Typo=Yes|VerbForm=Part|Voice=Pass	15	parataxis	15:parataxis	CorrectForm=affected
 26	:)	:)	SYM	NFP	_	3	discourse	3:discourse	_
 
 # sent_id = answers-20111108094504AAKrc8F_ans-0009
@@ -257,7 +257,7 @@
 22	how	how	ADV	WRB	PronType=Int	25	advmod	25:advmod	CxnElt=25:Interrogative-WHInfo-Indirect.WHWord
 23	things	thing	NOUN	NNS	Number=Plur	25	nsubj:pass	25:nsubj:pass	_
 24	get	get	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	25	aux:pass	25:aux:pass	_
-25	effected	effect	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	19	ccomp	19:ccomp	Cxn=Interrogative-WHInfo-Indirect|CxnElt=25:Interrogative-WHInfo-Indirect.Clause
+25	effected	affect	VERB	VBN	Tense=Past|Typo=Yes|VerbForm=Part|Voice=Pass	19	ccomp	19:ccomp	CorrectForm=affected|Cxn=Interrogative-WHInfo-Indirect|CxnElt=25:Interrogative-WHInfo-Indirect.Clause
 26	by	by	ADP	IN	_	27	case	27:case	_
 27	earthquakes	earthquake	NOUN	NNS	Number=Plur	25	obl:agent	25:obl:agent	SpaceAfter=No
 28	.	.	PUNCT	.	_	6	punct	6:punct	_

--- a/not-to-release/sources/answers/20111108100523AA1i7no_ans.xml.conllu
+++ b/not-to-release/sources/answers/20111108100523AA1i7no_ans.xml.conllu
@@ -217,7 +217,7 @@
 
 # sent_id = answers-20111108100523AA1i7no_ans-0010
 # text = Aquiriums are good also, but provide a mesh top for an easy airway.
-1	Aquiriums	aquirium	NOUN	NNS	Number=Plur	3	nsubj	3:nsubj|7:nsubj	_
+1	Aquiriums	aquarium	NOUN	NNS	Number=Plur|Typo=Yes	3	nsubj	3:nsubj|7:nsubj	CorrectForm=Aquariums
 2	are	be	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	3	cop	3:cop	_
 3	good	good	ADJ	JJ	Degree=Pos	0	root	0:root	_
 4	also	also	ADV	RB	_	3	advmod	3:advmod	SpaceAfter=No

--- a/not-to-release/sources/answers/20111108101827AALT6Zq_ans.xml.conllu
+++ b/not-to-release/sources/answers/20111108101827AALT6Zq_ans.xml.conllu
@@ -9,7 +9,7 @@
 5	for	for	ADP	IN	_	9	case	9:case	_
 6	canada	Canada	PROPN	NNP	Number=Sing	9	compound	9:compound	_
 7	skilled	skill	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	8	amod	8:amod	_
-8	immigeration	immigeration	NOUN	NN	Number=Sing	9	compound	9:compound	_
+8	immigeration	immigration	NOUN	NN	Number=Sing|Typo=Yes	9	compound	9:compound	CorrectForm=immigration
 9	program	program	NOUN	NN	Number=Sing	4	obl	4:obl:for	SpaceAfter=No
 10	.	.	PUNCT	.	_	2	punct	2:punct	SpaceAfter=No
 
@@ -22,7 +22,7 @@
 5	points	point	NOUN	NNS	Number=Plur	2	obj	2:obj	_
 6	while	while	SCONJ	IN	_	10	mark	10:mark	_
 7	67	67	NUM	CD	NumForm=Digit|NumType=Card	10	nsubj	10:nsubj	_
-8	minimunm	minimunm	NOUN	NN	Number=Sing	7	nmod:unmarked	7:nmod:unmarked	_
+8	minimunm	minimum	NOUN	NN	Number=Sing|Typo=Yes	7	nmod:unmarked	7:nmod:unmarked	CorrectForm=minimum
 9	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	10	cop	10:cop	_
 10	requirement	requirement	NOUN	NN	Number=Sing	2	advcl	2:advcl:while	SpaceAfter=No
 11	.?	.?	PUNCT	.	_	2	punct	2:punct	_

--- a/not-to-release/sources/answers/20111108102133AAwVd7m_ans.xml.conllu
+++ b/not-to-release/sources/answers/20111108102133AAwVd7m_ans.xml.conllu
@@ -357,7 +357,7 @@
 5	And	and	CCONJ	CC	_	9	cc	9:cc	_
 6	The	the	DET	DT	Definite=Def|PronType=Art	8	det	8:det	_
 7	Rat	Rat	PROPN	NNP	Number=Sing	8	compound	8:compound	_
-8	Calculater	calculater	NOUN	NN	Number=Sing	9	nsubj	9:nsubj	_
+8	Calculater	calculator	NOUN	NN	Number=Sing|Typo=Yes	9	nsubj	9:nsubj	CorrectForm=calculator
 9	Says	say	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	4	conj	4:conj:and	_
 10	Is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	11	cop	11:cop	_
 11	Big	big	ADJ	JJ	Degree=Pos	9	ccomp	9:ccomp	_

--- a/not-to-release/sources/answers/20111108102445AA5mfrq_ans.xml.conllu
+++ b/not-to-release/sources/answers/20111108102445AA5mfrq_ans.xml.conllu
@@ -74,7 +74,7 @@
 4	1	1	NUM	CD	NumForm=Digit|NumType=Card	5	nummod	5:nummod	_
 5	year	year	NOUN	NN	Number=Sing	3	obj	3:obj	_
 6	before	before	ADP	IN	_	7	case	7:case	_
-7	collage	collage	NOUN	NN	Number=Sing	3	obl	3:obl:before	SpaceAfter=No
+7	collage	college	NOUN	NN	Number=Sing|Typo=Yes	3	obl	3:obl:before	CorrectForm=college|SpaceAfter=No
 8	!	!	PUNCT	.	_	3	punct	3:punct	SpaceAfter=No
 9	)	)	PUNCT	-RRB-	_	3	punct	3:punct	_
 
@@ -600,9 +600,9 @@
 1	1	1	NUM	CD	NumForm=Digit|NumType=Card	2	nummod	2:nummod	_
 2	year	year	NOUN	NN	Number=Sing	4	nmod:unmarked	4:nmod:unmarked	_
 3	before	before	ADP	IN	_	4	case	4:case	_
-4	collage	collage	NOUN	NN	Number=Sing	0	root	0:root	_
+4	collage	collage	NOUN	NN	Number=Sing	0	root	0:root	Mentioned=Yes
 5	or	or	CCONJ	CC	_	6	cc	6:cc	_
-6	college	college	NOUN	NN	Number=Sing	4	conj	4:conj:or	SpaceAfter=No
+6	college	college	NOUN	NN	Number=Sing	4	conj	4:conj:or	Mentioned=Yes|SpaceAfter=No
 7	?	?	PUNCT	.	_	4	punct	4:punct	_
 
 # sent_id = answers-20111108102445AA5mfrq_ans-0038

--- a/not-to-release/sources/answers/20111108102810AAfCh1W_ans.xml.conllu
+++ b/not-to-release/sources/answers/20111108102810AAfCh1W_ans.xml.conllu
@@ -436,7 +436,7 @@
 14	in	in	ADP	IN	_	17	case	17:case	_
 15	another	another	DET	DT	PronType=Ind	17	det	17:det	_
 16	blog	blog	NOUN	NN	Number=Sing	17	compound	17:compound	_
-17	entery	entery	NOUN	NN	Number=Sing	12	obl	12:obl:in	SpaceAfter=No
+17	entery	entry	NOUN	NN	Number=Sing|Typo=Yes	12	obl	12:obl:in	CorrectForm=entry|SpaceAfter=No
 18	.	.	PUNCT	.	_	7	punct	7:punct	_
 
 # sent_id = answers-20111108102810AAfCh1W_ans-0018

--- a/not-to-release/sources/answers/20111108103211AA4XhnU_ans.xml.conllu
+++ b/not-to-release/sources/answers/20111108103211AA4XhnU_ans.xml.conllu
@@ -216,7 +216,7 @@
 # text = Lights are optinal since fish need the light turn off at night anyways and an air pump is not nessasary since they get air from the surface.
 1	Lights	light	NOUN	NNS	Number=Plur	3	nsubj	3:nsubj	_
 2	are	be	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	3	cop	3:cop	_
-3	optinal	optinal	ADJ	JJ	Degree=Pos	0	root	0:root	_
+3	optinal	optional	ADJ	JJ	Degree=Pos|Typo=Yes	0	root	0:root	CorrectForm=optional
 4	since	since	SCONJ	IN	_	6	mark	6:mark	_
 5	fish	fish	NOUN	NNS	Number=Plur	6	nsubj	6:nsubj	_
 6	need	need	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	3	advcl	3:advcl:since	_
@@ -233,7 +233,7 @@
 17	pump	pump	NOUN	NN	Number=Sing	20	nsubj	20:nsubj	_
 18	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	20	cop	20:cop	_
 19	not	not	PART	RB	Polarity=Neg	20	advmod	20:advmod	_
-20	nessasary	nessasary	ADJ	JJ	Degree=Pos	3	conj	3:conj:and	_
+20	nessasary	necessary	ADJ	JJ	Degree=Pos|Typo=Yes	3	conj	3:conj:and	CorrectForm=necessary
 21	since	since	SCONJ	IN	_	23	mark	23:mark	_
 22	they	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	23	nsubj	23:nsubj	_
 23	get	get	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	20	advcl	20:advcl:since	_

--- a/not-to-release/sources/answers/20111108103354AAQzdFB_ans.xml.conllu
+++ b/not-to-release/sources/answers/20111108103354AAQzdFB_ans.xml.conllu
@@ -144,7 +144,7 @@
 13	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	16	aux	16:aux	_
 14	also	also	ADV	RB	_	16	advmod	16:advmod	_
 15	not	not	PART	RB	Polarity=Neg	16	advmod	16:advmod	_
-16	useing	usee	VERB	VBG	Tense=Pres|VerbForm=Part	6	parataxis	6:parataxis	_
+16	useing	use	VERB	VBG	Tense=Pres|Typo=Yes|VerbForm=Part	6	parataxis	6:parataxis	CorrectForm=using
 17	the	the	DET	DT	Definite=Def|PronType=Art	18	det	18:det	_
 18	thing	thing	NOUN	NN	Number=Sing	16	obj	16:obj|21:obl	_
 19	that	that	PRON	WDT	PronType=Rel	21	obl	18:ref	_

--- a/not-to-release/sources/answers/20111108103957AAcF3iZ_ans.xml.conllu
+++ b/not-to-release/sources/answers/20111108103957AAcF3iZ_ans.xml.conllu
@@ -361,7 +361,7 @@
 12	one	one	NUM	CD	NumForm=Word|NumType=Card	11	obl:unmarked	11:obl:unmarked	_
 13	for	for	ADP	IN	_	15	case	15:case	_
 14	a	a	DET	DT	Definite=Ind|PronType=Art	15	det	15:det	_
-15	wile	wile	NOUN	NN	Number=Sing	11	obl	11:obl:for	SpaceAfter=No
+15	wile	while	NOUN	NN	Number=Sing|Typo=Yes	11	obl	11:obl:for	CorrectForm=while|SpaceAfter=No
 16	,	,	PUNCT	,	_	11	punct	11:punct	_
 17	then	then	ADV	RB	PronType=Dem	18	advmod	18:advmod	_
 18	up	up	ADV	RB	_	7	parataxis	5:xcomp|7:parataxis	_
@@ -443,7 +443,7 @@
 14	and	and	CCONJ	CC	_	15	cc	15:cc	_
 15	use	use	VERB	VB	VerbForm=Inf	6	conj	4:xcomp|6:conj:and	_
 16	your	your	PRON	PRP$	Case=Gen|Person=2|Poss=Yes|PronType=Prs	17	nmod:poss	17:nmod:poss	_
-17	wight	wight	NOUN	NN	Number=Sing	15	obj	15:obj	_
+17	wight	weight	NOUN	NN	Number=Sing|Typo=Yes	15	obj	15:obj	CorrectForm=weight
 18	correctly	correctly	ADV	RB	_	15	advmod	15:advmod	SpaceAfter=No
 19	,	,	PUNCT	,	_	21	punct	21:punct	_
 20	to	to	PART	TO	_	21	mark	21:mark	_
@@ -615,7 +615,7 @@
 1	maybe	maybe	ADV	RB	_	6	advmod	6:advmod	_
 2	a	a	DET	DT	Definite=Ind|PronType=Art	4	det	4:det	_
 3	back	back	NOUN	NN	Number=Sing	4	compound	4:compound	_
-4	brase	brase	NOUN	NN	Number=Sing	6	nsubj	6:nsubj	_
+4	brase	brace	NOUN	NN	Number=Sing|Typo=Yes	6	nsubj	6:nsubj	CorrectForm=brace
 5	will	will	AUX	MD	VerbForm=Fin	6	aux	6:aux	_
 6	help	help	VERB	VB	VerbForm=Inf	0	root	0:root	SpaceAfter=No
 7	,	,	PUNCT	,	_	12	punct	12:punct	_

--- a/not-to-release/sources/answers/20111108104015AAGxHNm_ans.xml.conllu
+++ b/not-to-release/sources/answers/20111108104015AAGxHNm_ans.xml.conllu
@@ -68,7 +68,7 @@
 35	it	it	PRON	PRP	Case=Nom|Gender=Neut|Number=Sing|Person=3|PronType=Prs	36	nsubj	36:nsubj	_
 36	work	work	VERB	VB	VerbForm=Inf	19	conj	16:xcomp|19:conj:and	_
 37	like	like	ADP	IN	_	38	case	38:case	_
-38	normall	normall	ADJ	JJ	Degree=Pos	36	obl	36:obl:like	SpaceAfter=No
+38	normall	normal	ADJ	JJ	Degree=Pos|Typo=Yes	36	obl	36:obl:like	CorrectForm=normal|SpaceAfter=No
 39	?	?	PUNCT	.	_	2	punct	2:punct	SpaceAfter=No
 
 # sent_id = answers-20111108104015AAGxHNm_ans-0003

--- a/not-to-release/sources/answers/20111108104131AAWUQHU_ans.xml.conllu
+++ b/not-to-release/sources/answers/20111108104131AAWUQHU_ans.xml.conllu
@@ -120,7 +120,7 @@
 11	the	the	DET	DT	Definite=Def|PronType=Art	12	det	12:det	_
 12	eggs	egg	NOUN	NNS	Number=Plur	16	nsubj	16:nsubj	_
 13	will	will	AUX	MD	VerbForm=Fin	16	aux	16:aux	_
-14	aways	aways	ADV	RB	_	16	advmod	16:advmod	_
+14	aways	always	ADV	RB	PronType=Tot|Typo=Yes	16	advmod	16:advmod	CorrectForm=always
 15	be	be	AUX	VB	VerbForm=Inf	16	cop	16:cop	_
 16	infertile	infertile	ADJ	JJ	Degree=Pos	0	root	0:root	Cxn=Conditional-UnspecifiedEpistemic-NoInversion|CxnElt=16:Conditional-UnspecifiedEpistemic-NoInversion.Apodosis|SpaceAfter=No
 17	.	.	PUNCT	.	_	16	punct	16:punct	_

--- a/not-to-release/sources/answers/20111108104228AA6z9uZ_ans.xml.conllu
+++ b/not-to-release/sources/answers/20111108104228AA6z9uZ_ans.xml.conllu
@@ -27,12 +27,12 @@
 15	graduated	graduate	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	4	conj	4:conj:and	_
 16	from	from	ADP	IN	_	17	case	17:case	_
 17	high	high	ADJ	JJ	Degree=Pos	15	obl	15:obl:from	_
-18	in	in	ADP	IN	_	20	case	20:case	_
-19	May	May	PROPN	NNP	Number=Sing	20	compound	20:compound	_
-20	adn	adn	NOUN	NN	Number=Sing	15	obl	15:obl:in	_
+18	in	in	ADP	IN	_	19	case	19:case	_
+19	May	May	PROPN	NNP	Number=Sing	15	obl	15:obl:in	_
+20	adn	adn	NOUN	NN	Number=Sing	23	reparandum	23:reparandum	_
 21	of	of	ADP	IN	_	23	case	23:case	_
 22	this	this	DET	DT	Number=Sing|PronType=Dem	23	det	23:det	_
-23	year	year	NOUN	NN	Number=Sing	20	nmod	20:nmod:of	_
+23	year	year	NOUN	NN	Number=Sing	19	nmod	19:nmod:of	_
 24	and	and	CCONJ	CC	_	26	cc	26:cc	_
 25	i	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	26	nsubj	26:nsubj	_
 26	love	love	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	4	conj	4:conj:and	_

--- a/not-to-release/sources/answers/20111108104551AAVAVQR_ans.xml.conllu
+++ b/not-to-release/sources/answers/20111108104551AAVAVQR_ans.xml.conllu
@@ -184,7 +184,7 @@
 7	,	,	PUNCT	,	_	10	punct	10:punct	_
 8	perfect	perfect	ADJ	JJ	Degree=Pos	10	amod	10:amod	_
 9	water	water	NOUN	NN	Number=Sing	10	compound	10:compound	_
-10	conditons	conditon	NOUN	NNS	Number=Plur	2	conj	2:conj:and	_
+10	conditons	condition	NOUN	NNS	Number=Plur|Typo=Yes	2	conj	2:conj:and	CorrectForm=conditions
 11	and	and	CCONJ	CC	_	14	cc	14:cc	_
 12	really	really	ADV	RB	_	13	advmod	13:advmod	_
 13	good	good	ADJ	JJ	Degree=Pos	14	amod	14:amod	_

--- a/not-to-release/sources/answers/20111108105225AAAJ9ek_ans.xml.conllu
+++ b/not-to-release/sources/answers/20111108105225AAAJ9ek_ans.xml.conllu
@@ -37,7 +37,7 @@
 11	i	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	12	nsubj	12:nsubj	_
 12	live	live	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	2	conj	2:conj:and	_
 13	in	in	ADP	IN	_	14	case	14:case	_
-14	forida	forida	PROPN	NNP	Number=Sing	12	obl	12:obl:in	SpaceAfter=No
+14	forida	Florida	PROPN	NNP	Number=Sing|Typo=Yes	12	obl	12:obl:in	CorrectForm=Florida|SpaceAfter=No
 15	.	.	PUNCT	.	_	2	punct	2:punct	_
 
 # sent_id = answers-20111108105225AAAJ9ek_ans-0004

--- a/not-to-release/sources/answers/20111108105400AASqPIh_ans.xml.conllu
+++ b/not-to-release/sources/answers/20111108105400AASqPIh_ans.xml.conllu
@@ -132,7 +132,7 @@
 13	this	this	DET	DT	Number=Sing|PronType=Dem	14	det	14:det	_
 14	procedure	procedure	NOUN	NN	Number=Sing	12	obj	12:obj	_
 15	like	like	ADP	IN	_	17	case	17:case	_
-16	Bumrungard	Bumrungard	PROPN	NNP	Number=Sing	17	compound	17:compound	_
+16	Bumrungard	Bumrungrad	PROPN	NNP	Number=Sing|Typo=Yes	17	compound	17:compound	CorrectForm=Bumrungrad
 17	Hospital	Hospital	PROPN	NNP	Number=Sing	6	nmod	6:nmod:like	_
 18	or	or	CCONJ	CC	_	20	cc	20:cc	_
 19	Yanhee	Yanhee	PROPN	NNP	Number=Sing	20	compound	20:compound	_

--- a/not-to-release/sources/answers/20111108105520AA73Axw_ans.xml.conllu
+++ b/not-to-release/sources/answers/20111108105520AA73Axw_ans.xml.conllu
@@ -634,7 +634,7 @@
 3	and	and	CCONJ	CC	_	4	cc	4:cc	_
 4	ammonia	ammonia	NOUN	NN	Number=Sing	2	conj	2:conj:and|10:nsubj	_
 5	(	(	PUNCT	-LRB-	_	6	punct	6:punct	SpaceAfter=No
-6	choramine	choramine	NOUN	NN	Number=Sing	2	appos	2:appos	SpaceAfter=No
+6	choramine	chloramine	NOUN	NN	Number=Sing|Typo=Yes	2	appos	2:appos	CorrectForm=chloramine|SpaceAfter=No
 7	)	)	PUNCT	-RRB-	_	6	punct	6:punct	_
 8	are	be	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	10	cop	10:cop	_
 9	not	not	PART	RB	Polarity=Neg	10	advmod	10:advmod	_

--- a/not-to-release/sources/answers/20111108110012AAK8Azy_ans.xml.conllu
+++ b/not-to-release/sources/answers/20111108110012AAK8Azy_ans.xml.conllu
@@ -51,7 +51,7 @@
 27	important	important	ADJ	JJ	Degree=Pos	26	amod	26:amod	_
 28	to	to	ADP	IN	_	33	case	33:case	_
 29	the	the	DET	DT	Definite=Def|PronType=Art	33	det	33:det	_
-30	psycholical	psycholical	ADJ	JJ	Degree=Pos	33	amod	33:amod	_
+30	psycholical	psychological	ADJ	JJ	Degree=Pos|Typo=Yes	33	amod	33:amod	CorrectForm=psychological
 31	well	well	ADJ	JJ	Degree=Pos	33	amod	33:amod	SpaceAfter=No
 32	-	-	PUNCT	HYPH	_	31	punct	31:punct	SpaceAfter=No
 33	being	being	NOUN	NN	Number=Sing	27	obl	27:obl:to	_
@@ -368,7 +368,7 @@
 10-11	Zoomed's	_	_	_	_	_	_	_	_
 10	Zoomed	Zoomed	PROPN	NNP	Number=Sing	13	nmod:poss	13:nmod:poss	_
 11	's	's	PART	POS	_	10	case	10:case	_
-12	Repsitun	Repsitun	PROPN	NNP	Number=Sing	13	compound	13:compound	_
+12	Repsitun	ReptiSun	PROPN	NNP	Number=Sing|Typo=Yes	13	compound	13:compound	CorrectForm=ReptiSun
 13	model	model	NOUN	NN	Number=Sing	7	obl	7:obl:like	SpaceAfter=No
 14	:	:	PUNCT	:	_	15	punct	15:punct	_
 15	http://lllreptile.com/store/catalog/reptile-supplies/uvb-fluorescent-lights-mercury-vapor-bulbs/-/zoo-med-24-repti-sun-100-fluorescent-bulb/	http://lllreptile.com/store/catalog/reptile-supplies/uvb-fluorescent-lights-mercury-vapor-bulbs/-/zoo-med-24-repti-sun-100-fluorescent-bulb/	PROPN	ADD	_	13	appos	13:appos	_

--- a/not-to-release/sources/answers/20111108110610AA4bcXX_ans.xml.conllu
+++ b/not-to-release/sources/answers/20111108110610AA4bcXX_ans.xml.conllu
@@ -176,7 +176,7 @@
 19	Everland	Everland	PROPN	NNP	Number=Sing	17	conj	13:appos|17:conj:and	SpaceAfter=No
 20	,	,	PUNCT	,	_	23	punct	23:punct	_
 21	and	and	CCONJ	CC	_	23	cc	23:cc	_
-22	Carribbean	Carribbean	PROPN	NNP	Number=Sing	23	compound	23:compound	_
+22	Carribbean	Caribbean	PROPN	NNP	Number=Sing|Typo=Yes	23	compound	23:compound	CorrectForm=Caribbean
 23	Bay	Bay	PROPN	NNP	Number=Sing	17	conj	13:appos|17:conj:and	SpaceAfter=No
 24	!	!	PUNCT	.	_	5	punct	5:punct	_
 
@@ -238,7 +238,7 @@
 
 # sent_id = answers-20111108110610AA4bcXX_ans-0015
 # text = Carribbean Bay: http://tong.visitkorea.or.kr/cms/resource/81/188181_image2_1.jpg
-1	Carribbean	Carribbean	PROPN	NNP	Number=Sing	2	compound	2:compound	_
+1	Carribbean	Caribbean	PROPN	NNP	Number=Sing|Typo=Yes	2	compound	2:compound	CorrectForm=Caribbean
 2	Bay	Bay	PROPN	NNP	Number=Sing	0	root	0:root	SpaceAfter=No
 3	:	:	PUNCT	:	_	4	punct	4:punct	_
 4	http://tong.visitkorea.or.kr/cms/resource/81/188181_image2_1.jpg	http://tong.visitkorea.or.kr/cms/resource/81/188181_image2_1.jpg	PROPN	ADD	_	2	appos	2:appos	_

--- a/not-to-release/sources/answers/20111108111031AARG57j_ans.xml.conllu
+++ b/not-to-release/sources/answers/20111108111031AARG57j_ans.xml.conllu
@@ -383,7 +383,7 @@
 34	and	and	CCONJ	CC	_	35	cc	35:cc	_
 35	lots	lot	NOUN	NNS	Number=Plur	18	conj	11:appos|18:conj:and	_
 36	of	of	ADP	IN	_	37	case	37:case	_
-37	repition	repition	NOUN	NN	Number=Sing	35	nmod	35:nmod:of	SpaceAfter=No
+37	repition	repetition	NOUN	NN	Number=Sing|Typo=Yes	35	nmod	35:nmod:of	CorrectForm=repetition|SpaceAfter=No
 38	....	....	PUNCT	,	_	39	punct	39:punct	SpaceAfter=No
 39	Right	right	INTJ	UH	_	11	discourse	11:discourse	SpaceAfter=No
 40	?	?	PUNCT	.	_	11	punct	11:punct	_

--- a/not-to-release/sources/answers/20111108111312AAq4ETn_ans.xml.conllu
+++ b/not-to-release/sources/answers/20111108111312AAq4ETn_ans.xml.conllu
@@ -161,7 +161,7 @@
 # text = I have tryed to give him water but he wont take it.. what should i do?
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	3	nsubj	3:nsubj|5:nsubj:xsubj	_
 2	have	have	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	3	aux	3:aux	_
-3	tryed	trye	VERB	VBN	Tense=Past|VerbForm=Part	0	root	0:root	_
+3	tryed	try	VERB	VBN	Tense=Past|Typo=Yes|VerbForm=Part	0	root	0:root	CorrectForm=tried
 4	to	to	PART	TO	_	5	mark	5:mark	_
 5	give	give	VERB	VB	VerbForm=Inf	3	xcomp	3:xcomp	_
 6	him	he	PRON	PRP	Case=Acc|Gender=Masc|Number=Sing|Person=3|PronType=Prs	5	iobj	5:iobj	_
@@ -269,7 +269,7 @@
 17	nt	not	PART	RB	Polarity=Neg|Typo=Yes	19	advmod	19:advmod	CorrectForm=n't
 18	be	be	AUX	VB	VerbForm=Inf	19	aux	19:aux	_
 19	buying	buy	VERB	VBG	Tense=Pres|VerbForm=Part	2	conj	2:conj:but	_
-20	grocerys	grocery	NOUN	NNS	Number=Plur	19	obj	19:obj	_
+20	grocerys	grocery	NOUN	NNS	Number=Plur|Typo=Yes	19	obj	19:obj	CorrectForm=groceries
 21	for	for	ADP	IN	_	25	case	25:case	_
 22	the	the	DET	DT	Definite=Def|PronType=Art	25	det	25:det	_
 23	next	next	ADJ	JJ	Degree=Pos	25	amod	25:amod	_

--- a/not-to-release/sources/email/enronsent00_01.xml.conllu
+++ b/not-to-release/sources/email/enronsent00_01.xml.conllu
@@ -320,7 +320,7 @@
 20	to	to	PART	TO	_	21	mark	21:mark	_
 21	implement	implement	VERB	VB	VerbForm=Inf	18	advcl	18:advcl:to	_
 22	the	the	DET	DT	Definite=Def|PronType=Art	23	det	23:det	_
-23	stategy	stategy	NOUN	NN	Number=Sing	21	obj	21:obj	SpaceAfter=No
+23	stategy	strategy	NOUN	NN	Number=Sing|Typo=Yes	21	obj	21:obj	CorrectForm=strategy|SpaceAfter=No
 24	.	.	PUNCT	.	_	2	punct	2:punct	_
 
 # sent_id = email-enronsent00_01-0017

--- a/not-to-release/sources/email/enronsent03_01.xml.conllu
+++ b/not-to-release/sources/email/enronsent03_01.xml.conllu
@@ -1597,7 +1597,7 @@
 5	at	at	ADP	IN	_	8	case	8:case	_
 6	your	your	PRON	PRP$	Case=Gen|Person=2|Poss=Yes|PronType=Prs	8	nmod:poss	8:nmod:poss	_
 7	earliest	early	ADJ	JJS	Degree=Sup	8	amod	8:amod	_
-8	convience	convience	NOUN	NN	Number=Sing	4	obl	4:obl:at	_
+8	convience	convenience	NOUN	NN	Number=Sing|Typo=Yes	4	obl	4:obl:at	CorrectForm=convenience
 9	if	if	SCONJ	IN	_	12	mark	12:mark	_
 10	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	12	nsubj	12:nsubj	_
 11	can	can	AUX	MD	VerbForm=Fin	12	aux	12:aux	_
@@ -1858,7 +1858,7 @@
 24	Planning	Planning	PROPN	NNP	Number=Sing	27	compound	27:compound	_
 25	and	and	CCONJ	CC	_	26	cc	26:cc	_
 26	Zoning	Zoning	PROPN	NNP	Number=Sing	24	conj	24:conj:and|27:compound	_
-27	dept	dept	PROPN	NNP	Number=Sing	17	obj	17:obj	_
+27	dept	department	PROPN	NNP	Abbr=Yes|Number=Sing	17	obj	17:obj	_
 28	regarding	regard	VERB	VBG	Tense=Pres|VerbForm=Part	31	case	31:case	_
 29	our	our	PRON	PRP$	Case=Gen|Number=Plur|Person=1|Poss=Yes|PronType=Prs	31	nmod:poss	31:nmod:poss	_
 30	permit	permit	NOUN	NN	Number=Sing	31	compound	31:compound	_

--- a/not-to-release/sources/email/enronsent08_02.xml.conllu
+++ b/not-to-release/sources/email/enronsent08_02.xml.conllu
@@ -7,7 +7,7 @@
 2	's	's	PART	POS	_	1	case	1:case	_
 3	birthday	birthday	NOUN	NN	Number=Sing	5	nsubj	5:nsubj	_
 4	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	5	cop	5:cop	_
-5	tommorow	tommorow	NOUN	NN	Number=Sing	0	root	0:root	SpaceAfter=No
+5	tommorow	tomorrow	NOUN	NN	Number=Sing|Typo=Yes	0	root	0:root	CorrectForm=tomorrow|SpaceAfter=No
 6	.	.	PUNCT	.	_	5	punct	5:punct	_
 
 # sent_id = email-enronsent08_02-0002
@@ -796,7 +796,7 @@
 2	him	he	PRON	PRP	Case=Acc|Gender=Masc|Number=Sing|Person=3|PronType=Prs	1	iobj	1:iobj	_
 3	a	a	DET	DT	Definite=Ind|PronType=Art	4	det	4:det	_
 4	call	call	NOUN	NN	Number=Sing	1	obj	1:obj	_
-5	tommorow	tommorow	NOUN	NN	Number=Sing	1	obl:unmarked	1:obl:unmarked	SpaceAfter=No|TemporalNPAdjunct=Yes
+5	tommorow	tomorrow	NOUN	NN	Number=Sing|Typo=Yes	1	obl:unmarked	1:obl:unmarked	CorrectForm=tomorrow|SpaceAfter=No|TemporalNPAdjunct=Yes
 6	.	.	PUNCT	.	_	1	punct	1:punct	_
 
 # sent_id = email-enronsent08_02-0060
@@ -889,8 +889,8 @@
 3-4	didn't	_	_	_	_	_	_	_	_
 3	did	do	AUX	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	5	aux	5:aux	_
 4	n't	not	PART	RB	Polarity=Neg	5	advmod	5:advmod	_
-5	spel	spel	VERB	VB	VerbForm=Inf	0	root	0:root	_
-6	anyting	anyting	NOUN	NN	Number=Sing	5	obj	5:obj	_
+5	spel	spell	VERB	VB	Typo=Yes|VerbForm=Inf	0	root	0:root	CorrectForm=sepll
+6	anyting	anything	PRON	NN	Number=Sing|PronType=Ind|Typo=Yes	5	obj	5:obj	CorrectForm=anything
 7	incorrectly	incorrectly	ADV	RB	_	5	advmod	5:advmod	SpaceAfter=No
 8	.	.	PUNCT	.	_	5	punct	5:punct	_
 

--- a/not-to-release/sources/email/enronsent09_01.xml.conllu
+++ b/not-to-release/sources/email/enronsent09_01.xml.conllu
@@ -497,7 +497,7 @@
 6	2000	2000	NUM	CD	NumForm=Digit|NumType=Card	4	obl	4:obl:in	_
 7	for	for	ADP	IN	_	9	case	9:case	_
 8	the	the	DET	DT	Definite=Def|PronType=Art	9	det	9:det	_
-9	acquistion	acquistion	NOUN	NN	Number=Sing	4	obl	4:obl:for	_
+9	acquistion	acquisition	NOUN	NN	Number=Sing|Typo=Yes	4	obl	4:obl:for	CorrectForm=acquisition
 10	of	of	ADP	IN	_	12	case	12:case	_
 11	WarpSpeed	WarpSpeed	PROPN	NNP	Number=Sing	12	compound	12:compound	_
 12	Communications	Communication	PROPN	NNPS	Number=Plur	9	nmod	9:nmod:of	_

--- a/not-to-release/sources/email/enronsent10_01.xml.conllu
+++ b/not-to-release/sources/email/enronsent10_01.xml.conllu
@@ -1633,7 +1633,7 @@
 12	's	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	15	cop	15:cop	_
 13	on	on	ADP	IN	_	15	case	15:case	_
 14	the	the	DET	DT	Definite=Def|PronType=Art	15	det	15:det	_
-15	phonne	phonne	NOUN	NN	Number=Sing	10	acl:relcl	10:acl:relcl	Cxn=rc-red-obl
+15	phonne	phone	NOUN	NN	Number=Sing|Typo=Yes	10	acl:relcl	10:acl:relcl	CorrectForm=phone|Cxn=rc-red-obl
 16	with	with	ADP	IN	_	17	case	17:case	_
 17	Gibson	Gibson	PROPN	NNP	Number=Sing	15	obl	15:obl:with	_
 18	or	or	CCONJ	CC	_	19	cc	19:cc	_

--- a/not-to-release/sources/email/enronsent11_01.xml.conllu
+++ b/not-to-release/sources/email/enronsent11_01.xml.conllu
@@ -33,7 +33,7 @@
 6	at	at	ADP	IN	_	7	case	7:case	_
 7	Index	index	NOUN	NN	Number=Sing	3	obl	3:obl:at	_
 8	and	and	CCONJ	CC	_	9	cc	9:cc	_
-9	sale	sale	VERB	VB	VerbForm=Inf	3	conj	3:conj:and	_
+9	sale	sell	VERB	VB	Typo=Yes|VerbForm=Inf	3	conj	3:conj:and	CorrectForm=sell
 10	Leach	Leach	PROPN	NNP	Number=Sing	9	obj	9:obj	_
 11	or	or	CCONJ	CC	_	12	cc	12:cc	_
 12	Pool	Pool	PROPN	NNP	Number=Sing	10	conj	9:obj|10:conj:or	_
@@ -87,7 +87,7 @@
 6	on	on	ADP	IN	_	9	case	9:case	_
 7	the	the	DET	DT	Definite=Def|PronType=Art	9	det	9:det	_
 8	Demand	demand	NOUN	NN	Number=Sing	9	compound	9:compound	_
-9	speadsheet	speadsheet	NOUN	NN	Number=Sing	4	nmod	4:nmod:on	SpaceAfter=No
+9	speadsheet	spreadsheet	NOUN	NN	Number=Sing|Typo=Yes	4	nmod	4:nmod:on	CorrectForm=spreadsheet|SpaceAfter=No
 10	.	.	PUNCT	.	_	2	punct	2:punct	_
 
 # sent_id = email-enronsent11_01-0006
@@ -1357,7 +1357,7 @@
 3	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	4	nsubj	4:nsubj|10:nsubj	_
 4	have	have	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	2	ccomp	2:ccomp	_
 5	your	your	PRON	PRP$	Case=Gen|Person=2|Poss=Yes|PronType=Prs	6	nmod:poss	6:nmod:poss	_
-6	anwser	anwser	NOUN	NN	Number=Sing	4	obj	4:obj	_
+6	anwser	answer	NOUN	NN	Number=Sing|Typo=Yes	4	obj	4:obj	CorrectForm=answer
 7	and	and	CCONJ	CC	_	10	cc	10:cc	_
 8-9	don't	_	_	_	_	_	_	_	_
 8	do	do	AUX	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	10	aux	10:aux	_

--- a/not-to-release/sources/email/enronsent12_01.xml.conllu
+++ b/not-to-release/sources/email/enronsent12_01.xml.conllu
@@ -625,7 +625,7 @@
 18	Gray	Gray	PROPN	NNP	Number=Sing	17	flat	17:flat	_
 19	at	at	ADP	IN	_	21	case	21:case	_
 20	Weil	Weil	PROPN	NNP	Number=Sing	21	compound	21:compound	_
-21	Gotschal	Gotschal	PROPN	NNP	Number=Sing	17	nmod	17:nmod:at	_
+21	Gotschal	Gotshal	PROPN	NNP	Number=Sing|Typo=Yes	17	nmod	17:nmod:at	CorrectForm=Gotshal
 22	in	in	ADP	IN	_	23	case	23:case	_
 23	Houston	Houston	PROPN	NNP	Number=Sing	21	nmod	21:nmod:in	_
 24	to	to	PART	TO	_	25	mark	25:mark	_

--- a/not-to-release/sources/email/enronsent13_01.xml.conllu
+++ b/not-to-release/sources/email/enronsent13_01.xml.conllu
@@ -361,7 +361,7 @@
 # text = If these amendmnets are agreeable to you can you please print and arrange for execution.
 1	If	if	SCONJ	IN	_	5	mark	5:mark	_
 2	these	this	DET	DT	Number=Plur|PronType=Dem	3	det	3:det	_
-3	amendmnets	amendmnet	NOUN	NNS	Number=Plur	5	nsubj	5:nsubj	_
+3	amendmnets	amendment	NOUN	NNS	Number=Plur|Typo=Yes	5	nsubj	5:nsubj	CorrectForm=amendments
 4	are	be	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	5	cop	5:cop	_
 5	agreeable	agreeable	ADJ	JJ	Degree=Pos	11	advcl	11:advcl:if	CxnElt=11:Conditional-UnspecifiedEpistemic-NoInversion.Protasis
 6	to	to	ADP	IN	_	7	case	7:case	_

--- a/not-to-release/sources/email/enronsent14_01.xml.conllu
+++ b/not-to-release/sources/email/enronsent14_01.xml.conllu
@@ -731,13 +731,13 @@
 23	and	and	CCONJ	CC	_	24	cc	24:cc	_
 24	experience	experience	NOUN	NN	Number=Sing	22	conj	19:obj|22:conj:and	_
 25	to	to	PART	TO	_	26	mark	26:mark	_
-26	persue	persue	VERB	VB	VerbForm=Inf	19	advcl	19:advcl:to	_
+26	persue	pursue	VERB	VB	Typo=Yes|VerbForm=Inf	19	advcl	19:advcl:to	CorrectForm=pursue
 27	my	my	PRON	PRP$	Case=Gen|Number=Sing|Person=1|Poss=Yes|PronType=Prs	28	nmod:poss	28:nmod:poss	_
 28	goals	goal	NOUN	NNS	Number=Plur	26	obj	26:obj	_
 29	in	in	ADP	IN	_	32	case	32:case	_
 30	the	the	DET	DT	Definite=Def|PronType=Art	32	det	32:det	_
 31	technology	technology	NOUN	NN	Number=Sing	32	compound	32:compound	_
-32	feild	feild	NOUN	NN	Number=Sing	28	nmod	28:nmod:in	SpaceAfter=No
+32	feild	field	NOUN	NN	Number=Sing|Typo=Yes	28	nmod	28:nmod:in	CorrectForm=field|SpaceAfter=No
 33	.	.	PUNCT	.	_	4	punct	4:punct	_
 
 # sent_id = email-enronsent14_01-0052
@@ -879,7 +879,7 @@
 29	in	in	ADP	IN	_	32	case	32:case	_
 30	the	the	DET	DT	Definite=Def|PronType=Art	32	det	32:det	_
 31	technology	technology	NOUN	NN	Number=Sing	32	compound	32:compound	_
-32	feild	feild	NOUN	NN	Number=Sing	28	nmod	28:nmod:in	SpaceAfter=No
+32	feild	field	NOUN	NN	Number=Sing|Typo=Yes	28	nmod	28:nmod:in	CorrectForm=field|SpaceAfter=No
 33	.	.	PUNCT	.	_	4	punct	4:punct	_
 
 # sent_id = email-enronsent14_01-0061
@@ -1820,6 +1820,6 @@
 11	due	due	ADJ	JJ	Degree=Pos|ExtPos=ADP	14	case	14:case	_
 12	to	to	ADP	IN	_	11	fixed	11:fixed	_
 13	previous	previous	ADJ	JJ	Degree=Pos	14	amod	14:amod	_
-14	committments	committment	NOUN	NNS	Number=Plur	8	obl	8:obl:due_to	SpaceAfter=No
+14	committments	commitment	NOUN	NNS	Number=Plur|Typo=Yes	8	obl	8:obl:due_to	CorrectForm=commitments|SpaceAfter=No
 15	.	.	PUNCT	.	_	8	punct	8:punct	_
 

--- a/not-to-release/sources/email/enronsent15_01.xml.conllu
+++ b/not-to-release/sources/email/enronsent15_01.xml.conllu
@@ -1424,7 +1424,7 @@
 
 # sent_id = email-enronsent15_01-0083
 # text = Tks,
-1	Tks	tks	NOUN	NN	Number=Sing	0	root	0:root	SpaceAfter=No
+1	Tks	thanks	NOUN	NN	Abbr=Yes|Number=Sing	0	root	0:root	SpaceAfter=No
 2	,	,	PUNCT	,	_	1	punct	1:punct	_
 
 # sent_id = email-enronsent15_01-0084

--- a/not-to-release/sources/email/enronsent17_01.xml.conllu
+++ b/not-to-release/sources/email/enronsent17_01.xml.conllu
@@ -161,7 +161,7 @@
 1	9	9	NUM	LS	NumForm=Digit|NumType=Card	3	discourse	3:discourse	SpaceAfter=No
 2	.	.	PUNCT	.	_	1	punct	1:punct	_
 3	Scott	Scott	PROPN	NNP	Number=Sing	0	root	0:root	_
-4	McNeally	McNeally	PROPN	NNP	Number=Sing	3	flat	3:flat	SpaceAfter=No
+4	McNeally	McNealy	PROPN	NNP	Number=Sing|Typo=Yes	3	flat	3:flat	CorrectForm=McNealy|SpaceAfter=No
 5	,	,	PUNCT	,	_	6	punct	6:punct	_
 6	CEO	ceo	NOUN	NN	Number=Sing	3	list	3:list	SpaceAfter=No
 7	,	,	PUNCT	,	_	9	punct	9:punct	_
@@ -941,7 +941,7 @@
 3	July	July	PROPN	NNP	Number=Sing	4	nmod:unmarked	4:nmod:unmarked	_
 4	12	12	NUM	CD	NumForm=Digit|NumType=Card	1	appos	1:appos	SpaceAfter=No
 5	,	,	PUNCT	,	_	6	punct	6:punct	_
-6	2:300	2:300	NUM	CD	NumForm=Digit|NumType=Card	1	nmod:unmarked	1:nmod:unmarked	TemporalNPAdjunct=Yes
+6	2:300	2:30	NUM	CD	NumForm=Digit|NumType=Card|Typo=Yes	1	nmod:unmarked	1:nmod:unmarked	CorrectForm=2:30|TemporalNPAdjunct=Yes
 7	will	will	AUX	MD	VerbForm=Fin	8	aux	8:aux	_
 8	work	work	VERB	VB	VerbForm=Inf	0	root	0:root	_
 9	for	for	ADP	IN	_	10	case	10:case	_

--- a/not-to-release/sources/email/enronsent18_01.xml.conllu
+++ b/not-to-release/sources/email/enronsent18_01.xml.conllu
@@ -110,7 +110,7 @@
 9	suitable	suitable	ADJ	JJ	Degree=Pos	13	amod	13:amod	_
 10	20	20	NUM	CD	NumForm=Digit|NumType=Card	11	nummod	11:nummod	_
 11	year	year	NOUN	NN	Number=Sing	12	compound	12:compound	_
-12	volalatility	volalatility	NOUN	NN	Number=Sing	13	compound	13:compound	_
+12	volalatility	volatility	NOUN	NN	Number=Sing|Typo=Yes	13	compound	13:compound	CorrectForm=volatility
 13	number	number	NOUN	NN	Number=Sing	7	obj	7:obj	_
 14	for	for	ADP	IN	_	17	case	17:case	_
 15	USD	usd	NOUN	NN	Number=Sing	17	compound	17:compound	SpaceAfter=No

--- a/not-to-release/sources/email/enronsent19_01.xml.conllu
+++ b/not-to-release/sources/email/enronsent19_01.xml.conllu
@@ -194,7 +194,7 @@
 
 # sent_id = email-enronsent19_01-0014
 # text = Columbia
-1	Columbia	Columbia	PROPN	NNP	Number=Sing	0	root	0:root	_
+1	Columbia	Colombia	PROPN	NNP	Number=Sing|Typo=Yes	0	root	0:root	CorrectForm=Colombia
 
 # sent_id = email-enronsent19_01-0015
 # text = Puerto Rico CPI only (I need historical inflation data, as well)
@@ -570,7 +570,7 @@
 5	-	-	PUNCT	,	_	9	punct	9:punct	_
 6	this	this	PRON	DT	Number=Sing|PronType=Dem	9	nsubj	9:nsubj	_
 7	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	9	cop	9:cop	_
-8	ling	ling	ADV	RB	_	9	advmod	9:advmod	_
+8	ling	long	ADV	RB	Typo=Yes	9	advmod	9:advmod	CorrectForm=long
 9	overdue	overdue	ADJ	JJ	Degree=Pos	1	parataxis	1:parataxis	_
 
 # sent_id = email-enronsent19_01-0041
@@ -642,7 +642,7 @@
 5	-	-	PUNCT	,	_	9	punct	9:punct	_
 6	this	this	PRON	DT	Number=Sing|PronType=Dem	9	nsubj	9:nsubj	_
 7	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	9	cop	9:cop	_
-8	ling	ling	ADV	RB	_	9	advmod	9:advmod	_
+8	ling	long	ADV	RB	Typo=Yes	9	advmod	9:advmod	CorrectForm=long
 9	overdue	overdue	ADJ	JJ	Degree=Pos	1	parataxis	1:parataxis	_
 
 # sent_id = email-enronsent19_01-0048

--- a/not-to-release/sources/email/enronsent19_02.xml.conllu
+++ b/not-to-release/sources/email/enronsent19_02.xml.conllu
@@ -49,7 +49,7 @@
 # sent_id = email-enronsent19_02-0006
 # text = My mane is Visit Phunnarungsi.
 1	My	my	PRON	PRP$	Case=Gen|Number=Sing|Person=1|Poss=Yes|PronType=Prs	2	nmod:poss	2:nmod:poss	_
-2	mane	mane	NOUN	NN	Number=Sing	5	nsubj	5:nsubj	_
+2	mane	name	NOUN	NN	Number=Sing|Typo=Yes	5	nsubj	5:nsubj	CorrectForm=name
 3	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	5	cop	5:cop	_
 4	Visit	Visit	PROPN	NNP	Number=Sing	5	compound	5:compound	_
 5	Phunnarungsi	Phunnarungsi	PROPN	NNP	Number=Sing	0	root	0:root	SpaceAfter=No
@@ -263,7 +263,7 @@
 5	if	if	SCONJ	IN	_	8	mark	8:mark	_
 6	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	8	nsubj	8:nsubj	_
 7	could	could	AUX	MD	VerbForm=Fin	8	aux	8:aux	_
-8	advice	advice	VERB	VB	VerbForm=Inf	4	advcl	4:advcl:if	CxnElt=4:Conditional-UnspecifiedEpistemic-NoInversion.Protasis
+8	advice	advise	VERB	VB	Typo=Yes|VerbForm=Inf	4	advcl	4:advcl:if	CorrectForm=advise|CxnElt=4:Conditional-UnspecifiedEpistemic-NoInversion.Protasis
 9	me	I	PRON	PRP	Case=Acc|Number=Sing|Person=1|PronType=Prs	8	obj	8:obj	_
 10	on	on	ADP	IN	_	12	case	12:case	_
 11	this	this	DET	DT	Number=Sing|PronType=Dem	12	det	12:det	_

--- a/not-to-release/sources/email/enronsent23_03.xml.conllu
+++ b/not-to-release/sources/email/enronsent23_03.xml.conllu
@@ -24,7 +24,7 @@
 10	the	the	DET	DT	Definite=Def|PronType=Art	11	det	11:det	_
 11	layoffs	layoff	NOUN	NNS	Number=Plur	8	nmod	8:nmod:of	_
 12	affect	affect	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	6	advcl	6:advcl:because	_
-13	satelite	satelite	NOUN	NN	Number=Sing	14	compound	14:compound	_
+13	satelite	sattelite	NOUN	NN	Number=Sing|Typo=Yes	14	compound	14:compound	CorrectForm=sattelite
 14	offices	office	NOUN	NNS	Number=Plur	12	obj	12:obj	SpaceAfter=No
 15	.	.	PUNCT	.	_	6	punct	6:punct	_
 

--- a/not-to-release/sources/email/enronsent23_11.xml.conllu
+++ b/not-to-release/sources/email/enronsent23_11.xml.conllu
@@ -19,7 +19,7 @@
 2	am	be	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	4	aux	4:aux	_
 3	not	not	PART	RB	Polarity=Neg	4	advmod	4:advmod	_
 4	looking	look	VERB	VBG	Tense=Pres|VerbForm=Part	0	root	0:root	_
-5	foward	foward	ADV	RB	_	4	advmod	4:advmod	_
+5	foward	forward	ADV	RB	Typo=Yes	4	advmod	4:advmod	CorrectForm=forward
 6	to	to	ADP	IN	_	7	case	7:case	_
 7	that	that	PRON	DT	Number=Sing|PronType=Dem	4	obl	4:obl:to	_
 8	but	but	CCONJ	CC	_	11	cc	11:cc	_

--- a/not-to-release/sources/email/enronsent23_14.xml.conllu
+++ b/not-to-release/sources/email/enronsent23_14.xml.conllu
@@ -258,8 +258,8 @@
 1	i	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	2	nsubj	2:nsubj	_
 2	satisfy	satisfy	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 3	your	your	PRON	PRP$	Case=Gen|Person=2|Poss=Yes|PronType=Prs	4	nmod:poss	4:nmod:poss	_
-4	appetitie	appetitie	NOUN	NN	Number=Sing	2	obj	2:obj	_
+4	appetitie	appetite	NOUN	NN	Number=Sing|Typo=Yes	2	obj	2:obj	CorrectForm=appetite
 5	for	for	ADP	IN	_	6	case	6:case	_
-6	lovin	lovin	NOUN	NN	Number=Sing	4	nmod	4:nmod:for	SpaceAfter=No
+6	lovin	lovin	NOUN	NN	Abbr=Yes|Number=Sing	4	nmod	4:nmod:for	SpaceAfter=No
 7	.	.	PUNCT	.	_	2	punct	2:punct	_
 

--- a/not-to-release/sources/email/enronsent27_01.xml.conllu
+++ b/not-to-release/sources/email/enronsent27_01.xml.conllu
@@ -325,7 +325,7 @@
 
 # sent_id = email-enronsent27_01-0022
 # text = Suerat (any works on paper? -
-1	Suerat	Suerat	PROPN	NNP	Number=Sing	0	root	0:root	_
+1	Suerat	Seurat	PROPN	NNP	Number=Sing|Typo=Yes	0	root	0:root	CorrectForm=Seurat
 2	(	(	PUNCT	-LRB-	_	4	punct	4:punct	SpaceAfter=No
 3	any	any	DET	DT	PronType=Ind	4	det	4:det	_
 4	works	work	NOUN	NNS	Number=Plur	1	parataxis	1:parataxis	_
@@ -374,7 +374,7 @@
 
 # sent_id = email-enronsent27_01-0029
 # text = Modrian
-1	Modrian	Modrian	PROPN	NNP	Number=Sing	0	root	0:root	_
+1	Modrian	Mondrian	PROPN	NNP	Number=Sing|Typo=Yes	0	root	0:root	CorrectForm=Mondrian
 
 # sent_id = email-enronsent27_01-0030
 # text = Rothko
@@ -792,7 +792,7 @@
 3	here	here	ADV	RB	PronType=Dem	0	root	0:root	_
 4	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	3	cop	3:cop	_
 5	the	the	DET	DT	Definite=Def|PronType=Art	7	det	7:det	_
-6	intial	intial	ADJ	JJ	Degree=Pos	7	amod	7:amod	_
+6	intial	initial	ADJ	JJ	Degree=Pos|Typo=Yes	7	amod	7:amod	CorrectForm=initial
 7	draft	draft	NOUN	NN	Number=Sing	3	nsubj	3:nsubj	SpaceAfter=No
 8	.	.	PUNCT	.	_	3	punct	3:punct	_
 

--- a/not-to-release/sources/email/enronsent29_01.xml.conllu
+++ b/not-to-release/sources/email/enronsent29_01.xml.conllu
@@ -238,16 +238,17 @@
 10	to	to	PART	TO	_	11	mark	11:mark	_
 11	discuss	discuss	VERB	VB	VerbForm=Inf	6	advcl	6:advcl:to	_
 12	any	any	DET	DT	PronType=Ind	13	det	13:det	_
-13	questionsand	questionsand	NOUN	NNS	Number=Plur	11	obj	11:obj|18:obj	_
-14	or	or	CCONJ	CC	_	15	cc	15:cc	_
-15	issues	issue	NOUN	NNS	Number=Plur	13	conj	11:obj|13:conj:or	_
-16	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	18	nsubj	18:nsubj	_
-17	may	may	AUX	MD	VerbForm=Fin	18	aux	18:aux	_
-18	have	have	VERB	VB	VerbForm=Inf	13	acl:relcl	13:acl:relcl	Cxn=rc-red-obj
-19	regarding	regard	VERB	VBG	Tense=Pres|VerbForm=Part	21	case	21:case	_
-20	this	this	DET	DT	Number=Sing|PronType=Dem	21	det	21:det	_
-21	matter	matter	NOUN	NN	Number=Sing	13	nmod	13:nmod:regarding	SpaceAfter=No
-22	.	.	PUNCT	.	_	6	punct	6:punct	_
+13	questions	question	NOUN	NNS	Number=Plur	11	obj	11:obj|18:obj	CorrectSpaceAfter=Yes|SpaceAfter=No
+14	and	and	CCONJ	CC	_	16	cc	16:cc	_
+15	or	or	CCONJ	CC	_	14	conj	14:conj	_
+16	issues	issue	NOUN	NNS	Number=Plur	13	conj	11:obj|13:conj:and_or	_
+17	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	19	nsubj	19:nsubj	_
+18	may	may	AUX	MD	VerbForm=Fin	19	aux	19:aux	_
+19	have	have	VERB	VB	VerbForm=Inf	13	acl:relcl	13:acl:relcl	Cxn=rc-red-obj
+20	regarding	regard	VERB	VBG	Tense=Pres|VerbForm=Part	22	case	22:case	_
+21	this	this	DET	DT	Number=Sing|PronType=Dem	22	det	22:det	_
+22	matter	matter	NOUN	NN	Number=Sing	13	nmod	13:nmod:regarding	SpaceAfter=No
+23	.	.	PUNCT	.	_	6	punct	6:punct	_
 
 # sent_id = email-enronsent29_01-0015
 # text = (See attached file: Constellation Power (GISB draft).doc)(See attached file: Sam3102.doc)
@@ -391,7 +392,7 @@
 
 # sent_id = email-enronsent29_01-0027
 # text = Thx
-1	Thx	thx	NOUN	NN	Number=Sing	0	root	0:root	_
+1	Thx	thanks	NOUN	NN	Abbr=Yes|Number=Sing	0	root	0:root	_
 
 # sent_id = email-enronsent29_01-0028
 # text = dp

--- a/not-to-release/sources/email/enronsent30_01.xml.conllu
+++ b/not-to-release/sources/email/enronsent30_01.xml.conllu
@@ -125,7 +125,7 @@
 # sent_id = email-enronsent30_01-0010
 # newpar id = email-enronsent30_01-p0004
 # text = Monday's starting next week at 4???????????????
-1	Monday's	Monday	PROPN	NNPS	Number=Plur	0	root	0:root	_
+1	Monday's	Monday	PROPN	NNPS	Number=Plur|Typo=Yes	0	root	0:root	CorrectForm=Mondays
 2	starting	start	VERB	VBG	VerbForm=Ger	1	acl	1:acl	_
 3	next	next	ADJ	JJ	Degree=Pos	4	amod	4:amod	_
 4	week	week	NOUN	NN	Number=Sing	2	obl:unmarked	2:obl:unmarked	TemporalNPAdjunct=Yes

--- a/not-to-release/sources/email/enronsent30_02.xml.conllu
+++ b/not-to-release/sources/email/enronsent30_02.xml.conllu
@@ -426,7 +426,7 @@
 3	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	7	cop	7:cop	_
 4	on	on	ADP	IN	_	7	case	7:case	_
 5	the	the	DET	DT	Definite=Def|PronType=Art	7	det	7:det	_
-6	fisrt	fisrt	ADJ	JJ	Degree=Pos	7	amod	7:amod	_
+6	fisrt	first	ADJ	JJ	Degree=Pos|Typo=Yes	7	amod	7:amod	CorrectForm=first
 7	tab	tab	NOUN	NN	Number=Sing	0	root	0:root	_
 8	of	of	ADP	IN	_	10	case	10:case	_
 9	the	the	DET	DT	Definite=Def|PronType=Art	10	det	10:det	_

--- a/not-to-release/sources/email/enronsent31_01.xml.conllu
+++ b/not-to-release/sources/email/enronsent31_01.xml.conllu
@@ -563,7 +563,7 @@
 19	to	to	ADP	IN	_	22	case	22:case	_
 20	the	the	DET	DT	Definite=Def|PronType=Art	22	det	22:det	_
 21	Admissions	admission	NOUN	NNS	Number=Plur	22	compound	22:compound	_
-22	commitee	commitee	NOUN	NN	Number=Sing	18	obl	18:obl:to	_
+22	commitee	committee	NOUN	NN	Number=Sing|Typo=Yes	18	obl	18:obl:to	CorrectForm=committee
 23	that	that	SCONJ	IN	_	26	mark	26:mark	_
 24	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	26	nsubj	26:nsubj	_
 25	can	can	AUX	MD	VerbForm=Fin	26	aux	26:aux	_
@@ -907,7 +907,7 @@
 19	to	to	ADP	IN	_	22	case	22:case	_
 20	the	the	DET	DT	Definite=Def|PronType=Art	22	det	22:det	_
 21	Admissions	admission	NOUN	NNS	Number=Plur	22	compound	22:compound	_
-22	committment	committment	NOUN	NN	Number=Sing	18	obl	18:obl:to	_
+22	committment	commitment	NOUN	NN	Number=Sing|Typo=Yes	18	obl	18:obl:to	CorrectForm=commitment
 23	that	that	SCONJ	IN	_	26	mark	26:mark	_
 24	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	26	nsubj	26:nsubj	_
 25	can	can	AUX	MD	VerbForm=Fin	26	aux	26:aux	_
@@ -934,7 +934,7 @@
 6	to	to	PART	TO	_	7	mark	7:mark	_
 7	continue	continue	VERB	VB	VerbForm=Inf	5	xcomp	5:xcomp	_
 8	our	our	PRON	PRP$	Case=Gen|Number=Plur|Person=1|Poss=Yes|PronType=Prs	9	nmod:poss	9:nmod:poss	_
-9	dialague	dialague	NOUN	NN	Number=Sing	7	obj	7:obj	_
+9	dialague	dialogue	NOUN	NN	Number=Sing|Typo=Yes	7	obj	7:obj	CorrectForm=dialogue
 10	regarding	regard	VERB	VBG	Tense=Pres|VerbForm=Part	11	mark	11:mark	_
 11	creating	create	VERB	VBG	VerbForm=Ger	9	acl	9:acl:regarding	_
 12	an	a	DET	DT	Definite=Ind|PronType=Art	18	det	18:det	_
@@ -1299,7 +1299,7 @@
 33	blend	blend	VERB	VB	VerbForm=Inf	31	advcl	31:advcl:to	_
 34	the	the	DET	DT	Definite=Def|PronType=Art	36	det	36:det	_
 35	two	two	NUM	CD	NumForm=Word|NumType=Card	36	nummod	36:nummod	_
-36	vols	vol	NOUN	NNS	Number=Plur	33	obj	33:obj	SpaceAfter=No
+36	vols	vol	NOUN	NNS	Abbr=Yes|Number=Plur	33	obj	33:obj	SpaceAfter=No
 37	)	)	PUNCT	-RRB-	_	26	punct	26:punct	SpaceAfter=No
 38	?	?	PUNCT	.	_	5	punct	5:punct	_
 

--- a/not-to-release/sources/email/enronsent32_02.xml.conllu
+++ b/not-to-release/sources/email/enronsent32_02.xml.conllu
@@ -366,7 +366,7 @@
 8	in	in	ADP	IN	_	11	case	11:case	_
 9	his	his	PRON	PRP$	Case=Gen|Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	11	nmod:poss	11:nmod:poss	_
 10	separate	separate	ADJ	JJ	Degree=Pos	11	amod	11:amod	_
-11	e'mail	e'mail	NOUN	NN	Number=Sing	7	obl	7:obl:in	SpaceAfter=No
+11	e'mail	e-mail	NOUN	NN	Number=Sing|Typo=Yes	7	obl	7:obl:in	CorrectForm=e-mail|SpaceAfter=No
 12	.	.	PUNCT	.	_	2	punct	2:punct	_
 
 # sent_id = email-enronsent32_02-0027

--- a/not-to-release/sources/email/enronsent33_01.xml.conllu
+++ b/not-to-release/sources/email/enronsent33_01.xml.conllu
@@ -401,7 +401,7 @@
 4	Joe	Joe	PROPN	NNP	Number=Sing	2	appos	2:appos	_
 5	Deffner	Deffner	PROPN	NNP	Number=Sing	4	flat	4:flat	SpaceAfter=No
 6	,	,	PUNCT	,	_	8	punct	8:punct	_
-7	Brain	Brain	PROPN	NNP	Number=Sing	8	compound	8:compound	_
+7	Brain	Brian	PROPN	NNP	Number=Sing|Typo=Yes	8	compound	8:compound	CorrectForm=Brian
 8	Kerrigan	Kerrigan	PROPN	NNP	Number=Sing	4	conj	2:appos|4:conj	SpaceAfter=No
 9	,	,	PUNCT	,	_	10	punct	10:punct	_
 10	Lewis	Lewis	PROPN	NNP	Number=Sing	4	conj	2:appos|4:conj	_
@@ -599,7 +599,7 @@
 8	any	any	DET	DT	PronType=Ind	11	det	11:det	_
 9	bad	bad	ADJ	JJ	Degree=Pos	11	amod	11:amod	_
 10	faith	faith	NOUN	NN	Number=Sing	11	compound	11:compound	_
-11	actins	actin	NOUN	NNS	Number=Plur	6	nmod	6:nmod:of|13:obj	_
+11	actins	action	NOUN	NNS	Number=Plur|Typo=Yes	6	nmod	6:nmod:of|13:obj	CorrectForm=actions
 12	Enron	Enron	PROPN	NNP	Number=Sing	13	nsubj	13:nsubj	_
 13	has	have	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	11	acl:relcl	11:acl:relcl	Cxn=rc-red-obj
 14	pending	pend	VERB	VBG	VerbForm=Ger	11	acl	11:acl	_
@@ -614,7 +614,7 @@
 23	who	who	PRON	WP	PronType=Rel	24	nsubj	21:ref	_
 24	manages	manage	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	21	acl:relcl	21:acl:relcl	Cxn=rc-wh-nsubj
 25	domestic	domestic	ADJ	JJ	Degree=Pos	26	amod	26:amod	_
-26	litgation	litgation	NOUN	NN	Number=Sing	24	obj	24:obj	_
+26	litgation	litigation	NOUN	NN	Number=Sing	24	obj	24:obj	CorrectForm=litigation
 27	here	here	ADV	RB	PronType=Dem	26	advmod	26:advmod	SpaceAfter=No
 28	.	.	PUNCT	.	_	4	punct	4:punct	_
 
@@ -1687,7 +1687,7 @@
 2-3	trustee's	_	_	_	_	_	_	_	_
 2	trustee	trustee	NOUN	NN	Number=Sing	5	nmod:poss	5:nmod:poss	_
 3	's	's	PART	POS	_	2	case	2:case	_
-4	oppositon	oppositon	NOUN	NN	Number=Sing	5	compound	5:compound	_
+4	oppositon	opposition	NOUN	NN	Number=Sing|Typo=Yes	5	compound	5:compound	CorrectForm=opposition
 5	papers	paper	NOUN	NNS	Number=Plur	8	nsubj	8:nsubj	_
 6	are	be	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	8	cop	8:cop	_
 7	now	now	ADV	RB	PronType=Dem	8	advmod	8:advmod	_

--- a/not-to-release/sources/email/enronsent34_01.xml.conllu
+++ b/not-to-release/sources/email/enronsent34_01.xml.conllu
@@ -111,7 +111,7 @@
 22	time	time	NOUN	NN	Number=Sing	17	obl	17:obl:at	_
 23	as	as	ADP	IN	_	25	case	25:case	_
 24	my	my	PRON	PRP$	Case=Gen|Number=Sing|Person=1|Poss=Yes|PronType=Prs	25	nmod:poss	25:nmod:poss	_
-25	parents	parent	NOUN	NNS	Number=Plur	22	nmod	22:nmod:as	SpaceAfter=No
+25	parents	parent	NOUN	NNS	Number=Plur	21	obl	21:obl:as	SpaceAfter=No
 26	.	.	PUNCT	.	_	4	punct	4:punct	_
 
 # sent_id = email-enronsent34_01-0008

--- a/not-to-release/sources/email/enronsent35_01.xml.conllu
+++ b/not-to-release/sources/email/enronsent35_01.xml.conllu
@@ -29,7 +29,7 @@
 2	you	you	PRON	PRP	Case=Acc|Person=2|PronType=Prs	1	obj	1:obj	_
 3	for	for	ADP	IN	_	5	case	5:case	_
 4	the	the	DET	DT	Definite=Def|PronType=Art	5	det	5:det	_
-5	invitaion	invitaion	NOUN	NN	Number=Sing	1	obl	1:obl:for	_
+5	invitaion	invitation	NOUN	NN	Number=Sing|Typo=Yes	1	obl	1:obl:for	CorrectForm=invitation
 6	to	to	ADP	IN	_	9	case	9:case	_
 7	the	the	DET	DT	Definite=Def|PronType=Art	9	det	9:det	_
 8	conference	conference	NOUN	NN	Number=Sing	9	compound	9:compound	_
@@ -1136,7 +1136,7 @@
 4	asked	ask	VERB	VBN	Tense=Past|VerbForm=Part	0	root	0:root	_
 5	about	about	ADP	IN	_	10	case	10:case	_
 6	the	the	DET	DT	Definite=Def|PronType=Art	10	det	10:det	_
-7	gtee	gtee	NOUN	NN	Number=Sing	10	compound	10:compound	_
+7	gtee	guarantee	NOUN	NN	Abbr=Yes|Number=Sing	10	compound	10:compound	_
 8	and	and	CCONJ	CC	_	9	cc	9:cc	_
 9	l/c	l/c	NOUN	NN	Number=Sing	7	conj	7:conj:and|10:compound	_
 10	wording	wording	NOUN	NN	Number=Sing	4	obl	4:obl:about	SpaceAfter=No
@@ -1168,7 +1168,7 @@
 5	fax	fax	VERB	VB	Mood=Sub|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	2	ccomp	2:ccomp	_
 6	the	the	DET	DT	Definite=Def|PronType=Art	9	det	9:det	_
 7	revised	revise	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	9	amod	9:amod	_
-8	gtee	gtee	NOUN	NN	Number=Sing	9	compound	9:compound	_
+8	gtee	guarantee	NOUN	NN	Abbr=Yes|Number=Sing	9	compound	9:compound	_
 9	wording	wording	NOUN	NN	Number=Sing	5	obj	5:obj|13:nsubj:pass	_
 10	that	that	PRON	WDT	PronType=Rel	13	nsubj:pass	9:ref	_
 11	has	have	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	13	aux	13:aux	_
@@ -1262,7 +1262,7 @@
 36	one's	one	NOUN	NNS	Number=Plur|Typo=Yes	27	advcl	27:advcl:if	CorrectForm=ones|CxnElt=27:Conditional-UnspecifiedEpistemic-NoInversion.Protasis
 37	issuing	issue	VERB	VBG	VerbForm=Ger	36	acl	36:acl	_
 38	the	the	DET	DT	Definite=Def|PronType=Art	39	det	39:det	_
-39	gtee	gtee	NOUN	NN	Number=Sing	37	obj	37:obj	_
+39	gtee	guarantee	NOUN	NN	Abbr=Yes|Number=Sing	37	obj	37:obj	_
 40	and	and	CCONJ	CC	_	41	cc	41:cc	_
 41	l/c	l/c	NOUN	NN	Number=Sing	39	conj	37:obj|39:conj:and	SpaceAfter=No
 42	.	.	PUNCT	.	_	2	punct	2:punct	_
@@ -1393,7 +1393,7 @@
 
 # sent_id = email-enronsent35_01-0113
 # text = Eleuthra?
-1	Eleuthra	Eleuthra	PROPN	NNP	Number=Sing	0	root	0:root	SpaceAfter=No
+1	Eleuthra	Eleuthera	PROPN	NNP	Number=Sing|Typo=Yes	0	root	0:root	CorrectForm=Eleuthera|SpaceAfter=No
 2	?	?	PUNCT	.	_	1	punct	1:punct	_
 
 # sent_id = email-enronsent35_01-0114
@@ -1855,7 +1855,7 @@
 
 # sent_id = email-enronsent35_01-0146
 # text = tks
-1	tks	tks	NOUN	NN	Number=Sing	0	root	0:root	_
+1	tks	thanks	NOUN	NN	Abbr=Yes|Number=Sing	0	root	0:root	_
 
 # sent_id = email-enronsent35_01-0147
 # newpar id = email-enronsent35_01-p0024

--- a/not-to-release/sources/email/enronsent36_01.xml.conllu
+++ b/not-to-release/sources/email/enronsent36_01.xml.conllu
@@ -107,7 +107,7 @@
 15	)	)	PUNCT	-RRB-	_	14	punct	14:punct	SpaceAfter=No
 16	]	]	PUNCT	-RRB-	_	7	punct	7:punct	_
 17	who	who	PRON	WP	PronType=Rel	18	nsubj	4:ref	_
-18	conrfirmed	conrfirm	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	4	acl:relcl	4:acl:relcl	Cxn=rc-wh-nsubj
+18	conrfirmed	confirm	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|Typo=Yes|VerbForm=Fin	4	acl:relcl	4:acl:relcl	CorrectForm=confirmed|Cxn=rc-wh-nsubj
 19	to	to	ADP	IN	_	20	case	20:case	_
 20	me	I	PRON	PRP	Case=Acc|Number=Sing|Person=1|PronType=Prs	18	obl	18:obl:to	_
 21	that	that	SCONJ	IN	_	24	mark	24:mark	_

--- a/not-to-release/sources/email/enronsent36_02.xml.conllu
+++ b/not-to-release/sources/email/enronsent36_02.xml.conllu
@@ -121,7 +121,7 @@
 5	POA	POA	NOUN	NN	Number=Sing	2	nmod	2:nmod:in	_
 6	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	11	cop	11:cop	_
 7	a	a	DET	DT	Definite=Ind|PronType=Art	11	det	11:det	_
-8	seperate	seperate	ADJ	JJ	Degree=Pos	11	amod	11:amod	_
+8	seperate	separate	ADJ	JJ	Degree=Pos|Typo=Yes	11	amod	11:amod	CorrectForm=separate
 9	and	and	CCONJ	CC	_	10	cc	10:cc	_
 10	distinct	distinct	ADJ	JJ	Degree=Pos	8	conj	8:conj:and|11:amod	_
 11	measure	measure	NOUN	NN	Number=Sing	0	root	0:root	_
@@ -852,7 +852,7 @@
 9	future	future	NOUN	NN	Number=Sing	3	nmod	3:nmod:in	SpaceAfter=No
 10	,	,	PUNCT	,	_	3	punct	3:punct	_
 11	the	the	DET	DT	Definite=Def|PronType=Art	16	det	16:det	_
-12	Houson	Houson	PROPN	NNP	Number=Sing	16	compound	16:compound	_
+12	Houson	Houston	PROPN	NNP	Number=Sing|Typo=Yes	16	compound	16:compound	CorrectForm=Houston
 13	and	and	CCONJ	CC	_	14	cc	14:cc	_
 14	London	London	PROPN	NNP	Number=Sing	12	conj	12:conj:and|16:compound	_
 15	credit	credit	NOUN	NN	Number=Sing	16	compound	16:compound	_

--- a/not-to-release/sources/email/enronsent37_01.xml.conllu
+++ b/not-to-release/sources/email/enronsent37_01.xml.conllu
@@ -874,7 +874,7 @@
 11	scenario	scenario	NOUN	NN	Number=Sing	0	root	0:root|15:obl	_
 12	where	where	ADV	WRB	PronType=Rel	15	advmod	11:ref	_
 13	a	a	DET	DT	Definite=Ind|PronType=Art	14	det	14:det	_
-14	muni	muni	NOUN	NN	Number=Sing	15	nsubj	15:nsubj|26:nsubj|33:nsubj	_
+14	muni	municipality	NOUN	NN	Abbr=Yes|Number=Sing	15	nsubj	15:nsubj|26:nsubj|33:nsubj	_
 15	does	do	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	11	acl:relcl	11:acl:relcl	Cxn=rc-wh-obl
 16	a	a	DET	DT	Definite=Ind|PronType=Art	18	det	18:det	_
 17	derivative	derivative	NOUN	NN	Number=Sing	18	compound	18:compound	_
@@ -1141,7 +1141,7 @@
 9	the	the	DET	DT	Definite=Def|PronType=Art	12	det	12:det	_
 10	Human	human	ADJ	JJ	Degree=Pos	11	amod	11:amod	_
 11	Resource	resource	NOUN	NN	Number=Sing	12	compound	12:compound	_
-12	dept	dept	NOUN	NN	Number=Sing	13	nsubj	13:nsubj	_
+12	dept	department	NOUN	NN	Abbr=Yes|Number=Sing	13	nsubj	13:nsubj	_
 13	said	say	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	3	conj	3:conj:but	_
 14	that	that	SCONJ	IN	_	25	mark	25:mark	_
 15	if	if	SCONJ	IN	_	21	mark	21:mark	_

--- a/not-to-release/sources/email/enronsent38_01.xml.conllu
+++ b/not-to-release/sources/email/enronsent38_01.xml.conllu
@@ -23,7 +23,7 @@
 8	should	should	AUX	MD	VerbForm=Fin	9	aux	9:aux	_
 9	be	be	VERB	VB	VerbForm=Inf	0	root	0:root	Cxn=Existential-CopPred-ThereExpl
 10	a	a	DET	DT	Definite=Ind|PronType=Art	11	det	11:det	_
-11	parentheses	parentheses	NOUN	NN	Number=Sing	9	nsubj	9:nsubj	CxnElt=9:Existential-CopPred-ThereExpl.Pivot
+11	parentheses	parenthesis	NOUN	NN	Number=Sing|Typo=Yes	9	nsubj	9:nsubj	CorrectForm=parenthesis|CorrectNumber=Sing|CxnElt=9:Existential-CopPred-ThereExpl.Pivot
 12	after	after	ADP	IN	_	13	case	13:case	_
 13	etc.	etc.	NOUN	FW	Abbr=Yes|Number=Plur	11	nmod	11:nmod:after	_
 14	in	in	ADP	IN	_	17	case	17:case	_
@@ -204,7 +204,7 @@
 5	the	the	DET	DT	Definite=Def|PronType=Art	7	det	7:det	_
 6	defined	define	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	7	amod	7:amod	_
 7	term	term	NOUN	NN	Number=Sing	10	nsubj:pass	10:nsubj:pass	_
-8	Govt	govt	NOUN	NN	Number=Sing	9	compound	9:compound	_
+8	Govt	government	NOUN	NN	Abbr=Yes|Number=Sing	9	compound	9:compound	_
 9	Authority	authority	NOUN	NN	Number=Sing	7	appos	7:appos	_
 10	used	use	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	0	root	0:root	Cxn=Interrogative-WHInfo-Direct|CxnElt=10:Interrogative-WHInfo-Direct.Clause|SpaceAfter=No
 11	?	?	PUNCT	.	_	10	punct	10:punct	_

--- a/not-to-release/sources/email/enronsent39_01.xml.conllu
+++ b/not-to-release/sources/email/enronsent39_01.xml.conllu
@@ -232,7 +232,7 @@
 13	time	time	NOUN	NN	Number=Sing	7	obl	7:obl:at	_
 14	as	as	ADP	IN	_	16	case	16:case	_
 15	our	our	PRON	PRP$	Case=Gen|Number=Plur|Person=1|Poss=Yes|PronType=Prs	16	nmod:poss	16:nmod:poss	_
-16	meetings	meeting	NOUN	NNS	Number=Plur	13	nmod	13:nmod:as	SpaceAfter=No
+16	meetings	meeting	NOUN	NNS	Number=Plur	12	obl	12:obl:as	SpaceAfter=No
 17	,	,	PUNCT	,	_	6	punct	6:punct	_
 18	the	the	DET	DT	Definite=Def|PronType=Art	20	det	20:det	_
 19	Grand	Grand	ADJ	NNP	Degree=Pos	20	amod	20:amod	_

--- a/not-to-release/sources/email/enronsent40_01.xml.conllu
+++ b/not-to-release/sources/email/enronsent40_01.xml.conllu
@@ -804,11 +804,11 @@
 2	and	and	CCONJ	CC	_	3	cc	3:cc	_
 3	myself	myself	PRON	PRP	Case=Acc|Number=Sing|Person=1|PronType=Prs|Reflex=Yes	1	conj	1:conj:and|5:nsubj|9:nsubj:xsubj	_
 4	are	be	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	5	aux	5:aux	_
-5	planing	plane	VERB	VBG	Tense=Pres|VerbForm=Part	0	root	0:root	_
+5	planing	plan	VERB	VBG	Tense=Pres|Typo=Yes|VerbForm=Part	0	root	0:root	CorrectForm=planning
 6	to	to	PART	TO	_	9	mark	9:mark	_
 7	be	be	AUX	VB	VerbForm=Inf	9	cop	9:cop	_
 8	in	in	ADP	IN	_	9	case	9:case	_
-9	Hoston	Hoston	PROPN	NNP	Number=Sing	5	xcomp	5:xcomp	_
+9	Hoston	Houston	PROPN	NNP	Number=Sing|Typo=Yes	5	xcomp	5:xcomp	CorrectForm=Houston
 10	on	on	ADP	IN	_	11	case	11:case	_
 11	Thursday	Thursday	PROPN	NNP	Number=Sing	9	obl	9:obl:on	_
 12	and	and	CCONJ	CC	_	13	cc	13:cc	_
@@ -1379,7 +1379,7 @@
 6	(	(	PUNCT	-LRB-	_	7	punct	7:punct	SpaceAfter=No
 7	Versailles	versaille	NOUN	NNS	Number=Plur	5	parataxis	5:parataxis	_
 8	or	or	CCONJ	CC	_	9	cc	9:cc	_
-9	Fontainbleu	Fontainbleu	PROPN	NNP	Number=Sing	7	conj	7:conj:or	_
+9	Fontainbleu	Fontainebleu	PROPN	NNP	Number=Sing|Typo=Yes	7	conj	7:conj:or	CorrectForm=Fontainebleu
 10	-	-	PUNCT	,	_	14	punct	14:punct	_
 11	half	half	ADJ	JJ	Degree=Pos|NumForm=Word|NumType=Frac	12	amod	12:amod	_
 12	day	day	NOUN	NN	Number=Sing	14	compound	14:compound	_

--- a/not-to-release/sources/email/enronsent42_01.xml.conllu
+++ b/not-to-release/sources/email/enronsent42_01.xml.conllu
@@ -702,7 +702,7 @@
 7	Gas	Gas	PROPN	NNP	Number=Sing	4	nmod	4:nmod:at	SpaceAfter=No
 8	-	-	PUNCT	,	_	10	punct	10:punct	SpaceAfter=No
 9	just	just	ADV	RB	_	10	advmod	10:advmod	_
-10	honro	honro	VERB	VB	Mood=Imp|VerbForm=Fin	2	parataxis	2:parataxis	_
+10	honro	honor	VERB	VB	Mood=Imp|Typo=Yes|VerbForm=Fin	2	parataxis	2:parataxis	CorrectForm=honor
 11	his	his	PRON	PRP$	Case=Gen|Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	12	nmod:poss	12:nmod:poss	_
 12	numbers	number	NOUN	NNS	Number=Plur	10	obj	10:obj	_
 

--- a/not-to-release/sources/email/enronsent43_01.xml.conllu
+++ b/not-to-release/sources/email/enronsent43_01.xml.conllu
@@ -1623,7 +1623,7 @@
 4	customers	customer	NOUN	NNS	Number=Plur	1	nmod	1:nmod:for	_
 5	were	be	AUX	VBD	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	6	aux:pass	6:aux:pass	_
 6	adjusted	adjust	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	0	root	0:root	_
-7	according	according	ADV	RB	_	6	advmod	6:advmod	SpaceAfter=No
+7	according	accordingly	ADV	RB	Typo=Yes	6	advmod	6:advmod	CorrectForm=accordingly|SpaceAfter=No
 8	.	.	PUNCT	.	_	6	punct	6:punct	_
 
 # sent_id = email-enronsent43_01-0096
@@ -1693,7 +1693,7 @@
 
 # sent_id = email-enronsent43_01-0102
 # text = Monday's are always tough.
-1	Monday's	Monday	PROPN	NNPS	Number=Plur	4	nsubj	4:nsubj	_
+1	Monday's	Monday	PROPN	NNPS	Number=Plur|Typo=Yes	4	nsubj	4:nsubj	CorrectForm=Mondays
 2	are	be	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	4	cop	4:cop	_
 3	always	always	ADV	RB	PronType=Tot	4	advmod	4:advmod	_
 4	tough	tough	ADJ	JJ	Degree=Pos	0	root	0:root	SpaceAfter=No

--- a/not-to-release/sources/newsgroup/groups.google.com_FOOLED_1bf9cdc5a4c2ac48_ENG_20050904_130400.xml.conllu
+++ b/not-to-release/sources/newsgroup/groups.google.com_FOOLED_1bf9cdc5a4c2ac48_ENG_20050904_130400.xml.conllu
@@ -967,9 +967,10 @@
 24	way	way	NOUN	NN	Number=Sing	11	ccomp	11:ccomp	_
 25	to	to	PART	TO	_	26	mark	26:mark	_
 26	invent	invent	VERB	VB	VerbForm=Inf	24	acl	24:acl:to	_
-27	the	the	DET	DT	Definite=Def|PronType=Art	28	det	28:det	_
-28	cellfone	cellfone	NOUN	NN	Number=Sing	26	obj	26:obj	SpaceAfter=No
-29	?	?	PUNCT	.	_	2	punct	2:punct	_
+27	the	the	DET	DT	Definite=Def|PronType=Art	29	det	29:det	_
+28	cell	cell	NOUN	NN	Number=Sing	29	compound	29:compound	CorrectSpaceAfter=Yes|SpaceAfter=No
+29	fone	phone	NOUN	NN	Number=Sing|Typo=Yes	26	obj	26:obj	CorrectForm=phone|SpaceAfter=No
+30	?	?	PUNCT	.	_	2	punct	2:punct	_
 
 # sent_id = newsgroup-groups.google.com_FOOLED_1bf9cdc5a4c2ac48_ENG_20050904_130400-0057
 # text = and bridges???

--- a/not-to-release/sources/newsgroup/groups.google.com_GuildWars_086f0f64ab633ab3_ENG_20041111_173500.xml.conllu
+++ b/not-to-release/sources/newsgroup/groups.google.com_GuildWars_086f0f64ab633ab3_ENG_20041111_173500.xml.conllu
@@ -295,7 +295,7 @@
 10	comes	come	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	6	advcl	6:advcl:when	_
 11	out	out	ADP	RP	_	10	compound:prt	10:compound:prt	_
 12	in	in	ADP	IN	_	13	case	13:case	_
-13	Febuary	Febuary	PROPN	NNP	Number=Sing	10	obl	10:obl:in	SpaceAfter=No
+13	Febuary	February	PROPN	NNP	Number=Sing|Typo=Yes	10	obl	10:obl:in	CorrectForm=February|SpaceAfter=No
 14	.	.	PUNCT	.	_	6	punct	6:punct	_
 
 # sent_id = newsgroup-groups.google.com_GuildWars_086f0f64ab633ab3_ENG_20041111_173500-0019
@@ -306,7 +306,7 @@
 4	05	05	NUM	CD	NumForm=Digit|NumType=Card	2	obj	2:obj	_
 5	on	on	ADP	IN	_	7	case	7:case	_
 6	the	the	DET	DT	Definite=Def|PronType=Art	7	det	7:det	_
-7	calender	calender	NOUN	NN	Number=Sing	2	obl	2:obl:on	SpaceAfter=No
+7	calender	calendar	NOUN	NN	Number=Sing|Typo=Yes	2	obl	2:obl:on	CorrectForm=calendar|SpaceAfter=No
 8	.	.	PUNCT	.	_	2	punct	2:punct	_
 
 # sent_id = newsgroup-groups.google.com_GuildWars_086f0f64ab633ab3_ENG_20041111_173500-0020

--- a/not-to-release/sources/newsgroup/groups.google.com_RagnarokOnlineII_acbece2a311cfb3c_ENG_20051119_076100.xml.conllu
+++ b/not-to-release/sources/newsgroup/groups.google.com_RagnarokOnlineII_acbece2a311cfb3c_ENG_20051119_076100.xml.conllu
@@ -59,7 +59,7 @@
 48	the	the	DET	DT	Definite=Def|PronType=Art	49	det	49:det	_
 49	links	link	NOUN	NNS	Number=Plur	47	obj	47:obj	_
 50	soon	soon	ADV	RB	Degree=Pos	47	advmod	47:advmod	_
-51	sry	sry	INTJ	UH	_	47	discourse	47:discourse	SpaceAfter=No
+51	sry	sorry	INTJ	UH	Abbr=Yes	47	discourse	47:discourse	SpaceAfter=No
 52	.	.	PUNCT	.	_	6	punct	6:punct	_
 
 # sent_id = newsgroup-groups.google.com_RagnarokOnlineII_acbece2a311cfb3c_ENG_20051119_076100-0003

--- a/not-to-release/sources/newsgroup/groups.google.com_alt.animals.badgers_172dcd8baf26948f_ENG_20040823_121900.xml.conllu
+++ b/not-to-release/sources/newsgroup/groups.google.com_alt.animals.badgers_172dcd8baf26948f_ENG_20040823_121900.xml.conllu
@@ -67,7 +67,7 @@
 7	the	the	DET	DT	Definite=Def|PronType=Art	12	det	12:det	_
 8	mind	mind	NOUN	NN	Number=Sing	9	compound	9:compound	_
 9	numbing	numb	VERB	VBG	VerbForm=Ger	12	amod	12:amod	_
-10	trailor	trailor	NOUN	NN	Number=Sing	11	compound	11:compound	_
+10	trailor	trailer	NOUN	NN	Number=Sing|Typo=Yes	11	compound	11:compound	CorrectForm=trailer
 11	trash	trash	NOUN	NN	Number=Sing	12	compound	12:compound	_
 12	cretins	cretin	NOUN	NNS	Number=Plur	5	obj	5:obj|19:nsubj	_
 13	out	out	ADV	RB	_	14	advmod	14:advmod	_

--- a/not-to-release/sources/newsgroup/groups.google.com_alt.animals.bears_07e0e03c803ffdbd_ENG_20040217_113500.xml.conllu
+++ b/not-to-release/sources/newsgroup/groups.google.com_alt.animals.bears_07e0e03c803ffdbd_ENG_20040217_113500.xml.conllu
@@ -209,7 +209,7 @@
 # sent_id = newsgroup-groups.google.com_alt.animals.bears_07e0e03c803ffdbd_ENG_20040217_113500-0014
 # text = We accecpt: Visa, MasterCard, Amex, Dinners Club/Carte Blanche, & Personal Checks/Money Orders.
 1	We	we	PRON	PRP	Case=Nom|Number=Plur|Person=1|PronType=Prs	2	nsubj	2:nsubj	_
-2	accecpt	accecpt	VERB	VBP	Mood=Ind|Number=Plur|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	SpaceAfter=No
+2	accecpt	accept	VERB	VBP	Mood=Ind|Number=Plur|Person=1|Tense=Pres|Typo=Yes|VerbForm=Fin	0	root	0:root	CorrectForm=accept|SpaceAfter=No
 3	:	:	PUNCT	:	_	4	punct	4:punct	_
 4	Visa	Visa	PROPN	NNP	Number=Sing	2	obj	2:obj	SpaceAfter=No
 5	,	,	PUNCT	,	_	6	punct	6:punct	_

--- a/not-to-release/sources/newsgroup/groups.google.com_alt.animals.cat_01ff709c4bf2c60c_ENG_20040418_040100.xml.conllu
+++ b/not-to-release/sources/newsgroup/groups.google.com_alt.animals.cat_01ff709c4bf2c60c_ENG_20040418_040100.xml.conllu
@@ -1116,7 +1116,7 @@
 6	this	this	DET	DT	Number=Sing|PronType=Dem	7	det	7:det	_
 7	piece	piece	NOUN	NN	Number=Sing	2	conj	2:conj:and|9:nsubj	SpaceAfter=No
 8	,	,	PUNCT	,	_	2	punct	2:punct	_
-9	effected	effect	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	0:root	_
+9	effected	affect	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|Typo=Yes|VerbForm=Fin	0	root	0:root	CorrectForm=affected
 10	me	I	PRON	PRP	Case=Acc|Number=Sing|Person=1|PronType=Prs	9	obj	9:obj	_
 11	enough	enough	ADV	RB	_	9	advmod	9:advmod	_
 12	to	to	PART	TO	_	13	mark	13:mark	_
@@ -1354,7 +1354,7 @@
 # sent_id = newsgroup-groups.google.com_alt.animals.cat_01ff709c4bf2c60c_ENG_20040418_040100-0059
 # text = --Shrodinger"
 1	--	--	PUNCT	NFP	_	2	punct	2:punct	SpaceAfter=No
-2	Shrodinger	Shrodinger	PROPN	NNP	Number=Sing	0	root	0:root	SpaceAfter=No
+2	Shrodinger	Schrödinger	PROPN	NNP	Number=Sing|Typo=Yes	0	root	0:root	CorrectForm=Schrödinger|SpaceAfter=No
 3	"	"	PUNCT	''	_	2	punct	2:punct	_
 
 # sent_id = newsgroup-groups.google.com_alt.animals.cat_01ff709c4bf2c60c_ENG_20040418_040100-0060

--- a/not-to-release/sources/newsgroup/groups.google.com_eHolistic_2dd76f31ceb6bfe8_ENG_20050513_224200.xml.conllu
+++ b/not-to-release/sources/newsgroup/groups.google.com_eHolistic_2dd76f31ceb6bfe8_ENG_20050513_224200.xml.conllu
@@ -24,7 +24,7 @@
 9	but	but	CCONJ	CC	_	12	cc	12:cc	_
 10	we	we	PRON	PRP	Case=Nom|Number=Plur|Person=1|PronType=Prs	12	nsubj	12:nsubj|18:nsubj|20:nsubj:xsubj	_
 11	are	be	AUX	VBP	Mood=Ind|Number=Plur|Person=1|Tense=Pres|VerbForm=Fin	12	cop	12:cop	_
-12	desparate	desparate	ADJ	JJ	Degree=Pos	2	conj	2:conj:but	_
+12	desparate	desperate	ADJ	JJ	Degree=Pos|Typo=Yes	2	conj	2:conj:but	CorrectForm=desperate
 13	in	in	ADP	IN	_	15	case	15:case	_
 14	our	our	PRON	PRP$	Case=Gen|Number=Plur|Person=1|Poss=Yes|PronType=Prs	15	nmod:poss	15:nmod:poss	_
 15	efforts	effort	NOUN	NNS	Number=Plur	12	obl	12:obl:in	_
@@ -95,7 +95,7 @@
 13	area	area	NOUN	NN	Number=Sing	10	nmod	10:nmod:in	SpaceAfter=No
 14	,	,	PUNCT	,	_	6	punct	6:punct	_
 15	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	16	aux	16:aux	_
-16	sponoring	sponor	VERB	VBG	Tense=Pres|VerbForm=Part	0	root	0:root	_
+16	sponoring	sponsor	VERB	VBG	Tense=Pres|Typo=Yes|VerbForm=Part	0	root	0:root	CorrectForm=sponsoring
 17	a	a	DET	DT	Definite=Ind|PronType=Art	18	det	18:det	_
 18	benefit	benefit	NOUN	NN	Number=Sing	16	obj	16:obj	_
 19	for	for	ADP	IN	_	22	case	22:case	_
@@ -213,7 +213,7 @@
 19	used	use	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	9	advcl	9:advcl:so_that	_
 20	for	for	ADP	IN	_	23	case	23:case	_
 21	a	a	DET	DT	Definite=Ind|PronType=Art	23	det	23:det	_
-22	humanatarian	humanatarian	ADJ	JJ	Degree=Pos	23	amod	23:amod	_
+22	humanatarian	humanitarian	ADJ	JJ	Degree=Pos|Typo=Yes	23	amod	23:amod	CorrectForm=humanitarian
 23	cause	cause	NOUN	NN	Number=Sing	19	obl	19:obl:for	SpaceAfter=No
 24	.	.	PUNCT	.	_	6	punct	6:punct	_
 

--- a/not-to-release/sources/newsgroup/groups.google.com_eHolistic_417b09016150421f_ENG_20051120_175800.xml.conllu
+++ b/not-to-release/sources/newsgroup/groups.google.com_eHolistic_417b09016150421f_ENG_20051120_175800.xml.conllu
@@ -171,7 +171,7 @@
 7	of	of	ADP	IN	_	8	case	8:case	_
 8	products	product	NOUN	NNS	Number=Plur	6	nmod	6:nmod:of	_
 9	called	call	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	6	acl	6:acl	_
-10	Gelceuticals	gelceutical	NOUN	NNS	Number=Plur	9	obj	9:obj	SpaceAfter=No
+10	Gelceuticals	Gelceutical	NOUN	NNS	Number=Plur	9	obj	9:obj	SpaceAfter=No
 11	.	.	PUNCT	.	_	2	punct	2:punct	_
 
 # sent_id = newsgroup-groups.google.com_eHolistic_417b09016150421f_ENG_20051120_175800-0014
@@ -204,7 +204,7 @@
 9	serving	serving	NOUN	NN	Number=Sing	10	compound	10:compound	_
 10	packets	packet	NOUN	NNS	Number=Plur	6	obj	6:obj|7:nsubj:xsubj	_
 11	of	of	ADP	IN	_	12	case	12:case	_
-12	Gelceuticals	gelceutical	NOUN	NNS	Number=Plur	10	nmod	10:nmod:of	SpaceAfter=No
+12	Gelceuticals	Gelceutical	NOUN	NNS	Number=Plur	10	nmod	10:nmod:of	SpaceAfter=No
 13	.	.	PUNCT	.	_	6	punct	6:punct	_
 
 # sent_id = newsgroup-groups.google.com_eHolistic_417b09016150421f_ENG_20051120_175800-0016

--- a/not-to-release/sources/newsgroup/groups.google.com_fineart_0339fc0ed4e53c5a_ENG_20050930_025500.xml.conllu
+++ b/not-to-release/sources/newsgroup/groups.google.com_fineart_0339fc0ed4e53c5a_ENG_20050930_025500.xml.conllu
@@ -71,7 +71,7 @@
 9	Avant	avant	NOUN	NN	Number=Sing	11	compound	11:compound	SpaceAfter=No
 10	-	-	PUNCT	HYPH	_	9	punct	9:punct	SpaceAfter=No
 11	Garde	garde	NOUN	NN	Number=Sing	12	compound	12:compound	_
-12	artist	artist	NOUN	NN	Number=Sing	5	nmod	5:nmod:of	_
+12	artist	artist	NOUN	NN	Number=Sing|Typo=Yes	5	nmod	5:nmod:of	CorrectForm=artists|CorrectNumber=Plur
 13	of	of	ADP	IN	_	15	case	15:case	_
 14	modern	modern	ADJ	JJ	Degree=Pos	15	amod	15:amod	_
 15	calligraphy	calligraphy	NOUN	NN	Number=Sing	12	nmod	12:nmod:of	SpaceAfter=No

--- a/not-to-release/sources/newsgroup/groups.google.com_herpesnation_c74170a0fcfdc880_ENG_20051125_075200.xml.conllu
+++ b/not-to-release/sources/newsgroup/groups.google.com_herpesnation_c74170a0fcfdc880_ENG_20051125_075200.xml.conllu
@@ -205,7 +205,7 @@
 # text = Any major dischord and we all suffer.
 1	Any	any	DET	DT	PronType=Ind	3	det	3:det	_
 2	major	major	ADJ	JJ	Degree=Pos	3	amod	3:amod	_
-3	dischord	dischord	NOUN	NN	Number=Sing	0	root	0:root	_
+3	dischord	discord	NOUN	NN	Number=Sing|Typo=Yes	0	root	0:root	CorrectForm=discord
 4	and	and	CCONJ	CC	_	7	cc	7:cc	_
 5	we	we	PRON	PRP	Case=Nom|Number=Plur|Person=1|PronType=Prs	7	nsubj	7:nsubj	_
 6	all	all	DET	DT	PronType=Tot	7	advmod	7:advmod	_

--- a/not-to-release/sources/newsgroup/groups.google.com_hiddennook_04d8cc994875d454_ENG_20050207_012300.xml.conllu
+++ b/not-to-release/sources/newsgroup/groups.google.com_hiddennook_04d8cc994875d454_ENG_20050207_012300.xml.conllu
@@ -22,7 +22,7 @@
 5	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	6	cop	6:cop	_
 6	ready	ready	ADJ	JJ	Degree=Pos	2	advcl	2:advcl:like	_
 7	to	to	PART	TO	_	8	mark	8:mark	_
-8	sour	sour	VERB	VB	VerbForm=Inf	6	xcomp	6:xcomp	_
+8	sour	soar	VERB	VB	Typo=Yes|VerbForm=Inf	6	xcomp	6:xcomp	CorrectForm=soar
 9	again	again	ADV	RB	_	8	advmod	8:advmod	_
 10	after	after	ADP	IN	_	13	case	13:case	_
 11	it's	its	PRON	PRP$	Case=Gen|Gender=Neut|Number=Sing|Person=3|Poss=Yes|PronType=Prs|Typo=Yes	13	nmod:poss	13:nmod:poss	CorrectForm=its

--- a/not-to-release/sources/newsgroup/groups.google.com_hiddennook_1fd8f731ae7ffaa0_ENG_20050214_192900.xml.conllu
+++ b/not-to-release/sources/newsgroup/groups.google.com_hiddennook_1fd8f731ae7ffaa0_ENG_20050214_192900.xml.conllu
@@ -201,7 +201,7 @@
 7	put	put	VERB	VB	VerbForm=Inf	0	root	0:root	_
 8	it	it	PRON	PRP	Case=Acc|Gender=Neut|Number=Sing|Person=3|PronType=Prs	7	obj	7:obj	_
 9	on	on	ADP	IN	_	10	case	10:case	_
-10	coarse	coarse	NOUN	NN	Number=Sing	7	obl	7:obl:on	_
+10	coarse	course	NOUN	NN	Number=Sing|Typo=Yes	7	obl	7:obl:on	CorrectForm=course
 11	for	for	ADP	IN	_	13	case	13:case	_
 12	global	global	ADJ	JJ	Degree=Pos	13	amod	13:amod	_
 13	domination	domination	NOUN	NN	Number=Sing	10	nmod	10:nmod:for	_

--- a/not-to-release/sources/newsgroup/groups.google.com_humanities.lit.authors.shakespeare_0018a7697318f71f_ENG_20031006_163200.xml.conllu
+++ b/not-to-release/sources/newsgroup/groups.google.com_humanities.lit.authors.shakespeare_0018a7697318f71f_ENG_20031006_163200.xml.conllu
@@ -423,7 +423,7 @@
 14	Don	Don	PROPN	NNP	Number=Sing	13	appos	13:appos	_
 15	Adriana	Adriana	PROPN	NNP	Number=Sing	14	flat	14:flat	_
 16	de	de	PROPN	NNP	Number=Sing	14	flat	14:flat	_
-17	Armatho	Armatho	PROPN	NNP	Number=Sing	14	flat	14:flat	SpaceAfter=No
+17	Armatho	Armado	PROPN	NNP	Number=Sing|Typo=Yes	14	flat	14:flat	CorrectForm=Armado|SpaceAfter=No
 18	,	,	PUNCT	,	_	19	punct	19:punct	_
 19	full	full	ADJ	JJ	Degree=Pos	13	amod	13:amod	_
 20	of	of	ADP	IN	_	21	case	21:case	_
@@ -830,7 +830,7 @@
 9	)	)	PUNCT	-RRB-	_	6	punct	6:punct	_
 10	was	be	AUX	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	14	cop	14:cop	_
 11	the	the	DET	DT	Definite=Def|PronType=Art	14	det	14:det	_
-12	Portugese	Portugese	ADJ	JJ	Degree=Pos	14	amod	14:amod	_
+12	Portugese	Portuguese	ADJ	JJ	Degree=Pos|Typo=Yes	14	amod	14:amod	CorrectForm=Portuguese
 13	Jewish	Jewish	ADJ	JJ	Degree=Pos	14	amod	14:amod	_
 14	doctor	doctor	NOUN	NN	Number=Sing	0	root	0:root	_
 15	accused	accuse	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	14	acl	14:acl	_
@@ -1051,7 +1051,7 @@
 12	)	)	PUNCT	-RRB-	_	7	punct	7:punct	_
 13	born	bear	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	1	parataxis	1:parataxis	_
 14	in	in	ADP	IN	_	15	case	15:case	_
-15	Calaria	Calaria	PROPN	NNP	Number=Sing	13	obl	13:obl:in	SpaceAfter=No
+15	Calaria	Calabria	PROPN	NNP	Number=Sing|Typo=Yes	13	obl	13:obl:in	CorrectForm=Calabria|SpaceAfter=No
 16	.	.	PUNCT	.	_	1	punct	1:punct	_
 
 # sent_id = newsgroup-groups.google.com_humanities.lit.authors.shakespeare_0018a7697318f71f_ENG_20031006_163200-0058
@@ -1233,7 +1233,7 @@
 9	in	in	ADP	IN	_	10	case	10:case	_
 10	presence	presence	NOUN	NN	Number=Sing	5	obl	5:obl:in	_
 11	of	of	ADP	IN	_	12	case	12:case	_
-12	Phillip	Phillip	PROPN	NNP	Number=Sing	10	nmod	10:nmod:of	FlatType=Enumerated
+12	Phillip	Philip	PROPN	NNP	Number=Sing|Typo=Yes	10	nmod	10:nmod:of	CorrectForm=Philip|FlatType=Enumerated
 13	II	II	NUM	CD	NumForm=Roman|NumType=Card	12	flat	12:flat	SpaceAfter=No
 14	.	.	PUNCT	.	_	5	punct	5:punct	_
 
@@ -1709,7 +1709,7 @@
 1	Of	of	ADP	IN	_	5	case	5:case	_
 2	all	all	DET	DT	PronType=Tot	5	det	5:det	_
 3	Freemason	Freemason	PROPN	NNP	Number=Sing	4	compound	4:compound	_
-4	sponsered	sponser	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	5	amod	5:amod	_
+4	sponsered	sponsor	VERB	VBN	Tense=Past|Typo=Yes|VerbForm=Part|Voice=Pass	5	amod	5:amod	CorrectForm=sponsored
 5	revolutions	revolution	NOUN	NNS	Number=Plur	23	obl	23:obl:of	SpaceAfter=No
 6	:	:	PUNCT	:	_	7	punct	7:punct	_
 7	American	American	ADJ	JJ	Degree=Pos	5	amod	5:amod	SpaceAfter=No

--- a/not-to-release/sources/newsgroup/groups.google.com_humanities.lit.authors.shakespeare_0c155162a7dfaf28_ENG_20031127_172200.xml.conllu
+++ b/not-to-release/sources/newsgroup/groups.google.com_humanities.lit.authors.shakespeare_0c155162a7dfaf28_ENG_20031127_172200.xml.conllu
@@ -252,7 +252,7 @@
 
 # sent_id = newsgroup-groups.google.com_humanities.lit.authors.shakespeare_0c155162a7dfaf28_ENG_20031127_172200-0015
 # text = Unemployent stays low because half the population oversees those "out of the workforce", the dregs, the rabble, the enemy?
-1	Unemployent	unemployent	NOUN	NN	Number=Sing	2	nsubj	2:nsubj|3:nsubj:xsubj	_
+1	Unemployent	unemployment	NOUN	NN	Number=Sing|Typo=Yes	2	nsubj	2:nsubj|3:nsubj:xsubj	CorrectForm=Unemployment
 2	stays	stay	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 3	low	low	ADJ	JJ	Degree=Pos	2	xcomp	2:xcomp	_
 4	because	because	SCONJ	IN	_	8	mark	8:mark	_

--- a/not-to-release/sources/newsgroup/groups.google.com_misc.consumers_628669ce346c590d_ENG_20040527_065700.xml.conllu
+++ b/not-to-release/sources/newsgroup/groups.google.com_misc.consumers_628669ce346c590d_ENG_20040527_065700.xml.conllu
@@ -627,7 +627,7 @@
 38	company	company	NOUN	NN	Number=Sing	33	nmod	33:nmod:of	SpaceAfter=No
 39	,	,	PUNCT	,	_	41	punct	41:punct	_
 40	and	and	CCONJ	CC	_	41	cc	41:cc	_
-41	Condoleeza	Condoleeza	PROPN	NNP	Number=Sing	11	conj	8:obj|11:conj:and|46:nmod:poss	_
+41	Condoleeza	Condoleezaa	PROPN	NNP	Number=Sing|Typo=Yes	11	conj	8:obj|11:conj:and|46:nmod:poss	CorrectForm=Condoleezaa
 42	Rice	Rice	PROPN	NNP	Number=Sing	41	flat	41:flat	SpaceAfter=No
 43	,	,	PUNCT	,	_	51	punct	51:punct	_
 44	whose	whose	PRON	WP$	Poss=Yes|PronType=Rel	46	nmod:poss	41:ref	_

--- a/not-to-release/sources/reviews/010820.xml.conllu
+++ b/not-to-release/sources/reviews/010820.xml.conllu
@@ -132,7 +132,7 @@
 4	out	out	ADP	RP	_	3	compound:prt	3:compound:prt	PRel[config]=default|PRel[gov]=3:move|Supersense=p.Direction
 5	from	from	ADP	IN	_	8	case	8:case	PRel[config]=default|PRel[gov]=3:move|PRel[obj]=8:apartment|Supersense=p.Source
 6	2	2	NUM	CD	NumForm=Digit|NumType=Card	7	nummod	7:nummod	_
-7	bdr	bdr	NOUN	NN	Number=Sing	8	compound	8:compound	Supersense=n.ARTIFACT
+7	bdr	bedroom	NOUN	NN	Abbr=Yes|Number=Sing	8	compound	8:compound	Supersense=n.ARTIFACT
 8	apartment	apartment	NOUN	NN	Number=Sing	3	obl	3:obl:from	Supersense=n.ARTIFACT
 9	and	and	CCONJ	CC	_	11	cc	11:cc	_
 10	it	it	PRON	PRP	Case=Nom|Gender=Neut|Number=Sing|Person=3|PronType=Prs	11	nsubj	11:nsubj	_

--- a/not-to-release/sources/reviews/029218.xml.conllu
+++ b/not-to-release/sources/reviews/029218.xml.conllu
@@ -53,7 +53,7 @@
 2	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	3	nsubj	3:nsubj	_
 3	need	need	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	17	advcl	17:advcl:if	CxnElt=17:Conditional-UnspecifiedEpistemic-NoInversion.Protasis|Supersense=v.cognition
 4	a	a	DET	DT	Definite=Ind|PronType=Art	5	det	5:det	_
-5	cater	cater	NOUN	NN	Number=Sing	3	obj	3:obj|8:nsubj|10:nsubj	Supersense=n.GROUP
+5	cater	caterer	NOUN	NN	Number=Sing|Typo=Yes	3	obj	3:obj|8:nsubj|10:nsubj	CorrectForm=caterer|Supersense=n.GROUP
 6	that	that	PRON	WDT	PronType=Rel	8	nsubj	5:ref	_
 7	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	8	cop	8:cop	Supersense=v.stative
 8	affordable	affordable	ADJ	JJ	Degree=Pos	5	acl:relcl	5:acl:relcl	Cxn=rc-that-nsubj-pstrand

--- a/not-to-release/sources/reviews/076440.xml.conllu
+++ b/not-to-release/sources/reviews/076440.xml.conllu
@@ -3,7 +3,7 @@
 # newpar id = reviews-076440-p0001
 # text = really amazing the new and exciting plays done at this theatre !
 1	really	really	ADV	RB	_	2	advmod	2:advmod	_
-2	amazing	amazing	ADJ	JJ	Degree=Pos	7	nsubj	7:nsubj	_
+2	amazing	amazing	ADJ	JJ	Degree=Pos	7	dislocated	7:dislocated	_
 3	the	the	DET	DT	Definite=Def|PronType=Art	7	det	7:det	_
 4	new	new	ADJ	JJ	Degree=Pos	7	amod	7:amod	_
 5	and	and	CCONJ	CC	_	6	cc	6:cc	_

--- a/not-to-release/sources/reviews/119026.xml.conllu
+++ b/not-to-release/sources/reviews/119026.xml.conllu
@@ -15,8 +15,8 @@
 11	the	the	DET	DT	Definite=Def|PronType=Art	12	det	12:det	_
 12	minute	minute	NOUN	NN	Number=Sing	23	obl:unmarked	14:obl|23:obl:unmarked	Supersense=n.TIME|TemporalNPAdjunct=Yes
 13	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	14	nsubj	14:nsubj	_
-14	steep	steep	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	12	acl:relcl	12:acl:relcl	Cxn=rc-red-obl|Supersense=v.motion
-15	into	into	ADP	IN	_	17	case	17:case	PRel[config]=default|PRel[gov]=14:steep|PRel[obj]=17:school|Supersense=p.Goal
+14	steep	step	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|Typo=Yes|VerbForm=Fin	12	acl:relcl	12:acl:relcl	CorrectForm=step|Cxn=rc-red-obl|Supersense=v.motion
+15	into	into	ADP	IN	_	17	case	17:case	PRel[config]=default|PRel[gov]=14:step|PRel[obj]=17:school|Supersense=p.Goal
 16	their	their	PRON	PRP$	Case=Gen|Number=Plur|Person=3|Poss=Yes|PronType=Prs	17	nmod:poss	17:nmod:poss	PRel[config]=possessive|PRel[gov]=17:school|Supersense[coding]=p.Possessor|Supersense[scene]=p.OrgMember
 17	school	school	NOUN	NN	Number=Sing	14	obl	14:obl:into	SpaceAfter=No|Supersense=n.LOCATION
 18	,	,	PUNCT	,	_	12	punct	12:punct	_

--- a/not-to-release/sources/weblog/blogspot.com_aggressivevoicedaily_20060629164800_ENG_20060629_164800.xml.conllu
+++ b/not-to-release/sources/weblog/blogspot.com_aggressivevoicedaily_20060629164800_ENG_20060629_164800.xml.conllu
@@ -15,7 +15,7 @@
 11	Rumsfeld	Rumsfeld	PROPN	NNP	Number=Sing	9	nmod	9:nmod:versus	_
 12	divided	divide	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	4	advcl	4:advcl	_
 13	along	along	ADP	IN	_	15	case	15:case	_
-14	idelogical	idelogical	ADJ	JJ	Degree=Pos	15	amod	15:amod	_
+14	idelogical	ideological	ADJ	JJ	Degree=Pos|Typo=Yes	15	amod	15:amod	CorrectForm=ideological
 15	lines	line	NOUN	NNS	Number=Plur	12	obl	12:obl:along	_
 16	with	with	SCONJ	IN	_	19	mark	19:mark	_
 17	John	John	PROPN	NNP	Number=Sing	19	nsubj	19:nsubj	_

--- a/not-to-release/sources/weblog/blogspot.com_dakbangla_20041119231111_ENG_20041119_231111.xml.conllu
+++ b/not-to-release/sources/weblog/blogspot.com_dakbangla_20041119231111_ENG_20041119_231111.xml.conllu
@@ -271,7 +271,7 @@
 10	expert	expert	NOUN	NN	Number=Sing	4	appos	4:appos	_
 11	at	at	ADP	IN	_	15	case	15:case	_
 12	the	the	DET	DT	Definite=Def|PronType=Art	15	det	15:det	_
-13	Jawaharal	Jawaharal	PROPN	NNP	Number=Sing	15	compound	15:compound	_
+13	Jawaharal	Jawaharlal	PROPN	NNP	Number=Sing|Typo=Yes	15	compound	15:compound	CorrectForm=Jawaharlal
 14	Nehru	Nehru	PROPN	NNP	Number=Sing	13	flat	13:flat	_
 15	University	University	PROPN	NNP	Number=Sing	10	nmod	10:nmod:at	SpaceAfter=No
 16	,	,	PUNCT	,	_	4	punct	4:punct	_

--- a/not-to-release/sources/weblog/blogspot.com_dakbangla_20050311135387_ENG_20050311_135387.xml.conllu
+++ b/not-to-release/sources/weblog/blogspot.com_dakbangla_20050311135387_ENG_20050311_135387.xml.conllu
@@ -38,7 +38,7 @@
 12	's	's	PART	POS	_	11	case	11:case	_
 13	taking	taking	NOUN	NN	Number=Sing	10	obj	10:obj	_
 14	of	of	ADP	IN	_	15	case	15:case	_
-15	mecca	mecca	PROPN	NNP	Number=Sing	13	nmod	13:nmod:of	_
+15	mecca	Mecca	PROPN	NNP	Number=Sing	13	nmod	13:nmod:of	_
 16	by	by	ADP	IN	_	19	case	19:case	_
 17	a	a	DET	DT	Definite=Ind|PronType=Art	19	det	19:det	_
 18	small	small	ADJ	JJ	Degree=Pos	19	amod	19:amod	_
@@ -1433,7 +1433,7 @@
 20	weapons	weapon	NOUN	NNS	Number=Plur	17	obj	17:obj	_
 21	as	as	ADP	IN	_	23	case	23:case	_
 22	their	their	PRON	PRP$	Case=Gen|Number=Plur|Person=3|Poss=Yes|PronType=Prs	23	nmod:poss	23:nmod:poss	_
-23	enemies	enemy	NOUN	NNS	Number=Plur	20	nmod	20:nmod:as	SpaceAfter=No
+23	enemies	enemy	NOUN	NNS	Number=Plur	19	obl	19:obl:as	SpaceAfter=No
 24	,	,	PUNCT	,	_	10	punct	10:punct	SpaceAfter=No
 25	"	"	PUNCT	''	_	10	punct	10:punct	_
 26	former	former	ADJ	JJ	Degree=Pos	32	amod	32:amod	_
@@ -1551,7 +1551,7 @@
 12	's	's	PART	POS	_	11	case	11:case	_
 13	taking	taking	NOUN	NN	Number=Sing	10	obj	10:obj	_
 14	of	of	ADP	IN	_	15	case	15:case	_
-15	mecca	mecca	PROPN	NNP	Number=Sing	13	nmod	13:nmod:of	_
+15	mecca	Mecca	PROPN	NNP	Number=Sing	13	nmod	13:nmod:of	_
 16	by	by	ADP	IN	_	19	case	19:case	_
 17	a	a	DET	DT	Definite=Ind|PronType=Art	19	det	19:det	_
 18	small	small	ADJ	JJ	Degree=Pos	19	amod	19:amod	_

--- a/not-to-release/sources/weblog/blogspot.com_floppingaces_20041126180010_ENG_20041126_180010.xml.conllu
+++ b/not-to-release/sources/weblog/blogspot.com_floppingaces_20041126180010_ENG_20041126_180010.xml.conllu
@@ -78,7 +78,7 @@
 8	few	few	ADJ	JJ	Degree=Pos	5	nmod	5:nmod:on	_
 9	of	of	ADP	IN	_	11	case	11:case	_
 10	the	the	DET	DT	Definite=Def|PronType=Art	11	det	11:det	_
-11	pic's	pic	NOUN	NNS	Number=Plur	8	nmod	8:nmod:of	SpaceAfter=No
+11	pic's	pic	NOUN	NNS	Abbr=Yes|Number=Plur|Typo=Yes	8	nmod	8:nmod:of	CorrectForm=pics|SpaceAfter=No
 12	.	.	PUNCT	.	_	2	punct	2:punct	_
 
 # sent_id = weblog-blogspot.com_floppingaces_20041126180010_ENG_20041126_180010-0005

--- a/not-to-release/sources/weblog/blogspot.com_gettingpolitical_20030906235000_ENG_20030906_235000.xml.conllu
+++ b/not-to-release/sources/weblog/blogspot.com_gettingpolitical_20030906235000_ENG_20030906_235000.xml.conllu
@@ -93,7 +93,7 @@
 12	a	a	DET	DT	Definite=Ind|PronType=Art	13	det	13:det	_
 13	wave	wave	NOUN	NN	Number=Sing	11	nsubj	11:nsubj	CxnElt=11:Existential-CopPred-ThereExpl.Pivot
 14	of	of	ADP	IN	_	17	case	17:case	_
-15	succesfull	succesfull	ADJ	JJ	Degree=Pos	17	amod	17:amod	_
+15	succesfull	successful	ADJ	JJ	Degree=Pos|Typo=Yes	17	amod	17:amod	CorrectForm=successful
 16	arab	Arab	ADJ	JJ	Degree=Pos	17	amod	17:amod	_
 17	attacks	attack	NOUN	NNS	Number=Plur	13	nmod	13:nmod:of	SpaceAfter=No
 18	.	.	PUNCT	.	_	3	punct	3:punct	_

--- a/not-to-release/sources/weblog/blogspot.com_healingiraq_20050121235804_ENG_20050121_235804.xml.conllu
+++ b/not-to-release/sources/weblog/blogspot.com_healingiraq_20050121235804_ENG_20050121_235804.xml.conllu
@@ -313,7 +313,7 @@
 5	that	that	SCONJ	IN	_	10	mark	10:mark	_
 6	"	"	PUNCT	``	_	8	punct	8:punct	SpaceAfter=No
 7	His	his	PRON	PRP$	Case=Gen|Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	8	nmod:poss	8:nmod:poss	_
-8	Emminence	Emminence	PROPN	NNP	Number=Sing	10	nsubj	10:nsubj|13:nsubj:xsubj	SpaceAfter=No
+8	Emminence	Eminence	PROPN	NNP	Number=Sing|Typo=Yes	10	nsubj	10:nsubj|13:nsubj:xsubj	CorrectForm=Eminence|SpaceAfter=No
 9	"	"	PUNCT	''	_	8	punct	8:punct	_
 10	decided	decide	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	4	ccomp	4:ccomp	_
 11	to	to	PART	TO	_	13	mark	13:mark	_
@@ -1095,7 +1095,7 @@
 31	many	many	ADJ	JJ	Degree=Pos	33	nsubj	33:nsubj	_
 32	have	have	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	33	aux	33:aux	_
 33	formed	form	VERB	VBN	Tense=Past|VerbForm=Part	24	advcl	24:advcl:though	_
-34	seperate	seperate	ADJ	JJ	Degree=Pos	35	amod	35:amod	_
+34	seperate	separate	ADJ	JJ	Degree=Pos|Typo=Yes	35	amod	35:amod	CorrectForm=separate
 35	cells	cell	NOUN	NNS	Number=Plur	33	obj	33:obj	_
 36	(	(	PUNCT	-LRB-	_	40	punct	40:punct	SpaceAfter=No
 37	often	often	ADV	RB	_	40	advmod	40:advmod	_

--- a/not-to-release/sources/weblog/blogspot.com_rigorousintuition_20050518101500_ENG_20050518_101500.xml.conllu
+++ b/not-to-release/sources/weblog/blogspot.com_rigorousintuition_20050518101500_ENG_20050518_101500.xml.conllu
@@ -1155,7 +1155,7 @@
 7	Lynn	Lynn	PROPN	NNP	Number=Sing	14	nsubj	14:nsubj	_
 8	Hughes	Hughes	PROPN	NNP	Number=Sing	7	flat	7:flat	_
 9	in	in	ADP	IN	_	10	case	10:case	_
-10	Huston	Huston	PROPN	NNP	Number=Sing	7	nmod	7:nmod:in	SpaceAfter=No
+10	Huston	Houston	PROPN	NNP	Number=Sing|Typo=Yes	7	nmod	7:nmod:in	CorrectForm=Houston|SpaceAfter=No
 11	,	,	PUNCT	,	_	12	punct	12:punct	_
 12	Texas	Texas	PROPN	NNP	Number=Sing	10	nmod:unmarked	10:nmod:unmarked	SpaceAfter=No|Superlocation=Yes
 13	,	,	PUNCT	,	_	7	punct	7:punct	_
@@ -1218,7 +1218,7 @@
 7	head	head	NOUN	NN	Number=Sing	5	obj	5:obj	_
 8	again	again	ADV	RB	_	5	advmod	5:advmod	_
 9	in	in	ADP	IN	_	10	case	10:case	_
-10	Louisianna	Louisianna	PROPN	NNP	Number=Sing	5	obl	5:obl:in	SpaceAfter=No
+10	Louisianna	Louisiana	PROPN	NNP	Number=Sing|Typo=Yes	5	obl	5:obl:in	CorrectForm=Louisiana|SpaceAfter=No
 11	..	..	PUNCT	.	_	1	punct	1:punct	_
 
 # sent_id = weblog-blogspot.com_rigorousintuition_20050518101500_ENG_20050518_101500-0054

--- a/not-to-release/sources/weblog/blogspot.com_rigorousintuition_20060511134300_ENG_20060511_134300.xml.conllu
+++ b/not-to-release/sources/weblog/blogspot.com_rigorousintuition_20060511134300_ENG_20060511_134300.xml.conllu
@@ -3333,7 +3333,7 @@
 12	"	"	PUNCT	''	_	11	punct	11:punct	_
 13	when	when	ADV	WRB	PronType=Int	16	advmod	16:advmod	_
 14	they	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	16	nsubj	16:nsubj	_
-15	indescriminately	indescriminately	ADV	RB	_	16	advmod	16:advmod	_
+15	indescriminately	indiscriminately	ADV	RB	Typo=Yes	16	advmod	16:advmod	CorrectForm=indiscriminately
 16	murdered	murder	VERB	VBD	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	6	advcl	6:advcl:when	_
 17	their	their	PRON	PRP$	Case=Gen|Number=Plur|Person=3|Poss=Yes|PronType=Prs	18	nmod:poss	18:nmod:poss	_
 18	classmates	classmate	NOUN	NNS	Number=Plur	16	obj	16:obj	SpaceAfter=No
@@ -3782,7 +3782,7 @@
 5	:	:	PUNCT	:	_	24	punct	24:punct	_
 6	When	when	ADV	WRB	PronType=Int	11	advmod	11:advmod	_
 7	the	the	DET	DT	Definite=Def|PronType=Art	10	det	10:det	_
-8	appartently	appartently	ADV	RB	_	10	advmod	10:advmod	_
+8	appartently	apparently	ADV	RB	Typo=Yes	10	advmod	10:advmod	CorrectForm=apparently
 9	cognitively	cognitively	ADV	RB	_	10	advmod	10:advmod	_
 10	functional	functional	ADJ	JJ	Degree=Pos	11	nsubj	11:nsubj	_
 11	take	take	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	24	advcl	24:advcl:when	_
@@ -5346,11 +5346,11 @@
 # sent_id = weblog-blogspot.com_rigorousintuition_20060511134300_ENG_20060511_134300-0256
 # text = But succintly making point after succint point, the text of the letter stands on its own merit, regardless.
 1	But	but	CCONJ	CC	_	14	cc	14:cc	_
-2	succintly	succintly	ADV	RB	_	3	advmod	3:advmod	_
+2	succintly	succinctly	ADV	RB	Typo=Yes	3	advmod	3:advmod	CorrectForm=succinctly
 3	making	make	VERB	VBG	Tense=Pres|VerbForm=Part	14	advcl	14:advcl	_
 4	point	point	NOUN	NN	Number=Sing	3	obj	3:obj	_
 5	after	after	ADP	IN	_	7	case	7:case	_
-6	succint	succint	ADJ	JJ	Degree=Pos	7	amod	7:amod	_
+6	succint	succinct	ADJ	JJ	Degree=Pos|Typo=Yes	7	amod	7:amod	CorrectForm=succinct
 7	point	point	NOUN	NN	Number=Sing	4	nmod	4:nmod:after	SpaceAfter=No
 8	,	,	PUNCT	,	_	3	punct	3:punct	_
 9	the	the	DET	DT	Definite=Def|PronType=Art	10	det	10:det	_
@@ -6045,7 +6045,7 @@
 25	top	top	NOUN	NN	Number=Sing	22	nmod	22:nmod:at	_
 26	of	of	ADP	IN	_	30	case	30:case	_
 27	a	a	DET	DT	Definite=Ind|PronType=Art	30	det	30:det	_
-28	pyrimidal	pyrimidal	ADJ	JJ	Degree=Pos	30	amod	30:amod	_
+28	pyrimidal	pyramidal	ADJ	JJ	Degree=Pos|Typo=Yes	30	amod	30:amod	CorrectForm=pyramidal
 29	power	power	NOUN	NN	Number=Sing	30	compound	30:compound	_
 30	structure	structure	NOUN	NN	Number=Sing	25	nmod	25:nmod:of	SpaceAfter=No
 31	)	)	PUNCT	-RRB-	_	22	punct	22:punct	_

--- a/not-to-release/sources/weblog/blogspot.com_tacitusproject_20040712123425_ENG_20040712_123425.xml.conllu
+++ b/not-to-release/sources/weblog/blogspot.com_tacitusproject_20040712123425_ENG_20040712_123425.xml.conllu
@@ -11,7 +11,7 @@
 7	other	other	ADJ	JJ	Degree=Pos	8	amod	8:amod	_
 8	writers	writer	NOUN	NNS	Number=Plur	6	obj	6:obj	_
 9	at	at	ADP	IN	_	10	case	10:case	_
-10	legnth	legnth	NOUN	NN	Number=Sing	6	obl	6:obl:at	_
+10	legnth	length	NOUN	NN	Number=Sing|Typo=Yes	6	obl	6:obl:at	CorrectForm=length
 11	in	in	ADP	IN	_	13	case	13:case	_
 12	this	this	DET	DT	Number=Sing|PronType=Dem	13	det	13:det	_
 13	space	space	NOUN	NN	Number=Sing	6	obl	6:obl:in	SpaceAfter=No

--- a/not-to-release/sources/weblog/juancole.com_juancole_20040114085100_ENG_20040114_085100.xml.conllu
+++ b/not-to-release/sources/weblog/juancole.com_juancole_20040114085100_ENG_20040114_085100.xml.conllu
@@ -70,7 +70,7 @@
 14	briefly	briefly	ADV	RB	_	15	advmod	15:advmod	_
 15	arrested	arrest	VERB	VBD	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	7	advcl	7:advcl:when	_
 16	a	a	DET	DT	Definite=Ind|PronType=Art	19	det	19:det	_
-17	yound	yound	ADJ	JJ	Degree=Pos	19	amod	19:amod	_
+17	yound	young	ADJ	JJ	Degree=Pos|Typo=Yes	19	amod	19:amod	CorrectForm=young
 18	newlywed	newlywed	ADJ	JJ	Degree=Pos	19	amod	19:amod	_
 19	bride	bride	NOUN	NN	Number=Sing	15	obj	15:obj	SpaceAfter=No
 20	.	.	PUNCT	.	_	7	punct	7:punct	_

--- a/not-to-release/sources/weblog/juancole.com_juancole_20041109060653_ENG_20041109_060653.xml.conllu
+++ b/not-to-release/sources/weblog/juancole.com_juancole_20041109060653_ENG_20041109_060653.xml.conllu
@@ -246,7 +246,7 @@
 3	the	the	DET	DT	Definite=Def|PronType=Art	4	det	4:det	_
 4	Occupation	occupation	NOUN	NN	Number=Sing	6	nsubj	6:nsubj	_
 5	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	6	cop	6:cop	_
-6	emphemeral	emphemeral	ADJ	JJ	Degree=Pos	1	ccomp	1:ccomp	SpaceAfter=No
+6	emphemeral	ephemeral	ADJ	JJ	Degree=Pos|Typo=Yes	1	ccomp	1:ccomp	CorrectForm=ephemeral|SpaceAfter=No
 7	.	.	PUNCT	.	_	1	punct	1:punct	SpaceAfter=No
 8	"	"	PUNCT	''	_	1	punct	1:punct	_
 
@@ -359,7 +359,7 @@
 5	ploy	ploy	NOUN	NN	Number=Sing	2	xcomp	2:xcomp	SpaceAfter=No
 6	"	"	PUNCT	''	_	5	punct	5:punct	_
 7	the	the	DET	DT	Definite=Def|PronType=Art	8	det	8:det	_
-8	assertaion	assertaion	NOUN	NN	Number=Sing	2	obj	2:obj|5:nsubj:xsubj	_
+8	assertaion	assertion	NOUN	NN	Number=Sing|Typo=Yes	2	obj	2:obj|5:nsubj:xsubj	CorrectForm=assertion
 9	that	that	SCONJ	IN	_	16	mark	16:mark	_
 10	the	the	DET	DT	Definite=Def|PronType=Art	11	det	11:det	_
 11	attack	attack	NOUN	NN	Number=Sing	16	nsubj	16:nsubj	_

--- a/not-to-release/sources/weblog/juancole.com_juancole_20041111060900_ENG_20041111_060900.xml.conllu
+++ b/not-to-release/sources/weblog/juancole.com_juancole_20041111060900_ENG_20041111_060900.xml.conllu
@@ -174,7 +174,7 @@
 24	if	if	SCONJ	IN	_	30	mark	30:mark	_
 25	the	the	DET	DT	Definite=Def|PronType=Art	27	det	27:det	_
 26	Fallujah	Fallujah	PROPN	NNP	Number=Sing	27	compound	27:compound	_
-27	compaign	compaign	NOUN	NN	Number=Sing	30	nsubj:pass	30:nsubj:pass	_
+27	compaign	campaign	NOUN	NN	Number=Sing|Typo=Yes	30	nsubj:pass	30:nsubj:pass	CorrectForm=campaign
 28	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	30	aux:pass	30:aux:pass	_
 29	not	not	PART	RB	Polarity=Neg	30	advmod	30:advmod	_
 30	stopped	stop	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	22	advcl	22:advcl:if	CxnElt=22:Conditional-UnspecifiedEpistemic-NoInversion.Protasis|SpaceAfter=No

--- a/not-to-release/sources/weblog/juancole.com_juancole_20051126063000_ENG_20051126_063000.xml.conllu
+++ b/not-to-release/sources/weblog/juancole.com_juancole_20051126063000_ENG_20051126_063000.xml.conllu
@@ -912,7 +912,7 @@
 15	rights	right	NOUN	NNS	Number=Plur	11	obj	11:obj	_
 16	as	as	ADP	IN	_	18	case	18:case	_
 17	other	other	ADJ	JJ	Degree=Pos	18	amod	18:amod	_
-18	Iraqis	Iraqi	PROPN	NNPS	Number=Plur	15	nmod	15:nmod:as	SpaceAfter=No
+18	Iraqis	Iraqi	PROPN	NNPS	Number=Plur	14	obl	14:obl:as	SpaceAfter=No
 19	.	.	PUNCT	.	_	11	punct	11:punct	_
 
 # sent_id = weblog-juancole.com_juancole_20051126063000_ENG_20051126_063000-0038

--- a/not-to-release/sources/weblog/typepad.com_ripples_20040407125600_ENG_20040407_125600.xml.conllu
+++ b/not-to-release/sources/weblog/typepad.com_ripples_20040407125600_ENG_20040407_125600.xml.conllu
@@ -272,7 +272,7 @@
 22	and	and	CCONJ	CC	_	23	cc	23:cc	_
 23	Elimination	Elimination	PROPN	NNP	Number=Sing	19	conj	16:nmod:on|19:conj:and	_
 24	of	of	ADP	IN	_	25	case	25:case	_
-25	Conseguences	Conseguence	PROPN	NNPS	Number=Plur	23	nmod	23:nmod:of	_
+25	Conseguences	Consequence	PROPN	NNPS	Number=Plur|Typo=Yes	23	nmod	23:nmod:of	CorrectForm=Consequences
 26	of	of	ADP	IN	_	28	case	28:case	_
 27	Natural	Natural	ADJ	NNP	Degree=Pos	28	amod	28:amod	_
 28	Disasters	Disaster	PROPN	NNPS	Number=Plur	25	nmod	25:nmod:of	_

--- a/not-to-release/sources/weblog/typepad.com_ripples_20050410122300_ENG_20050410_122300.xml.conllu
+++ b/not-to-release/sources/weblog/typepad.com_ripples_20050410122300_ENG_20050410_122300.xml.conllu
@@ -304,7 +304,7 @@
 6-7	Ben's	_	_	_	_	_	_	_	_
 6	Ben	Ben	PROPN	NNP	Number=Sing	8	nmod:poss	8:nmod:poss	_
 7	's	's	PART	POS	_	6	case	6:case	_
-8	annoucement	annoucement	NOUN	NN	Number=Sing	4	nmod	4:nmod:of	_
+8	annoucement	announcement	NOUN	NN	Number=Sing|Typo=Yes	4	nmod	4:nmod:of	CorrectForm=announcement
 9	yesterday	yesterday	NOUN	NN	Number=Sing	8	nmod:unmarked	8:nmod:unmarked	SpaceAfter=No|TemporalNPAdjunct=Yes
 10	,	,	PUNCT	,	_	4	punct	4:punct	_
 11	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	12	nsubj	12:nsubj	_


### PR DESCRIPTION
I ran this today using Georgetown's subscription to Gemini (I can't find the exact version).

### Protocol

1. Split the data into chunks of about 600 sentences (24 files for EWT).
2. For each one, open a new chat, upload the file, and issue the two prompts below.
3. Manually review the results and implement the valid corrections.

### First prompt

In Fast mode:

>    Analyze the word lines of the file. Retain the entire line exactly as it is in the file.
>
>    Print the lines for misspelled words. Only print lines that do not have Typo=Yes or Abbr=Yes.
>
>    Ignore capitalization errors.

### Second prompt

In Thinking mode (expand the reasoning trace as well):

>    Are there any others?

Doing it this way gives fairly high precision results. It uncovers a good number of typos including contextual misspellings and proper names that I didn't know. This one was particularly nuanced:

<img width="560" height="156" alt="image" src="https://github.com/user-attachments/assets/3e034b61-aa73-4807-b598-31bb5f30be06" />

### Results

Nearly 200 fixes (some were abbreviations rather than typos; a couple were tokenization fixes; one was a missed instance of the `dislocated` relation).

As can be seen from the list of edited files, only 4 were from the Reviews genre. This is because this subset had already been heavily scrutinized in developing STREUSLE.